### PR TITLE
fix: correct env var names in .env.local.example files

### DIFF
--- a/research-sentry/.env.local.example
+++ b/research-sentry/.env.local.example
@@ -1,3 +1,3 @@
 # Rename to .env.local and add your keys
 OPENAI_API_KEY=sk-your-key-here
-MINO_API_KEY=your-mino-key-here
+TINYFISH_API_KEY=your-tinyfish-key-here

--- a/tinyskills/.env.local.example
+++ b/tinyskills/.env.local.example
@@ -1,5 +1,5 @@
-# Mino API key for web automation
-MINO_API_KEY=your_mino_api_key
+# Tinyfish API key for web automation
+TINYFISH_API_KEY=your_tinyfish_api_key
 
 # OpenRouter API key for AI generation
 OPENROUTER_API_KEY=your_openrouter_api_key


### PR DESCRIPTION
## Summary

Fix environment variable name mismatch between `.env.local.example` documentation and actual code usage.

## Problem

Both `research-sentry` and `tinyskills` projects document `MINO_API_KEY` in their `.env.local.example` files, but the code reads `TINYFISH_API_KEY` from the environment. Anyone following the setup instructions would set the wrong variable and have a silently broken Tinyfish integration.

## Changes

- `research-sentry/.env.local.example`: `MINO_API_KEY` -> `TINYFISH_API_KEY`
- `tinyskills/.env.local.example`: `MINO_API_KEY` -> `TINYFISH_API_KEY`

## Evidence

- `research-sentry/lib/mino.ts` line 10: `process.env.TINYFISH_API_KEY`
- `tinyskills/app/api/scrape-sources/route.ts` line 51: `process.env.TINYFISH_API_KEY`
