### PR TITLE
fix: replace non-null assertion with optional chaining in pricing calc

### DIFF
--- a/competitor-analysis/app/company/[id]/page.tsx
+++ b/competitor-analysis/app/company/[id]/page.tsx
@@ -31,7 +31,7 @@ export default function CompanyDetailPage() {
   const competitorStartingPrices = Object.entries(state.scrapingResults)
     .filter(([, r]) => r.status === "complete" && r.data?.tiers)
     .map(([id, r]) => {
-      const prices = r.data!.tiers
+      const prices = (r.data?.tiers ?? [])
         .map((t) => t.monthlyPrice ?? t.price)
         .filter((p): p is number => typeof p === "number" && p > 0);
       return {


### PR DESCRIPTION
## Problem

In `competitor-analysis/app/company/[id]/page.tsx`, line 34 uses a non-null assertion (`r.data!.tiers`) after a `.filter()` that checks `r.data?.tiers`. TypeScript does not narrow types through `.filter().map()` chains, so the assertion was used as a workaround. However, if the filter predicate is refactored or the data shape changes, this could cause a runtime `TypeError`.

## Fix

Replace `r.data!.tiers` with `(r.data?.tiers ?? [])`. The empty array fallback produces an empty `prices` array, which correctly results in `price: 0` and gets filtered out by the subsequent `.filter(c => c.price > 0)`.

**1 file changed, 1 insertion, 1 deletion.**
