### PR TITLE
fix: use nullish coalescing for hotel availability field

### DIFF
--- a/stay-scout-hub/src/lib/api/hotel-search.ts
+++ b/stay-scout-hub/src/lib/api/hotel-search.ts
@@ -113,7 +113,7 @@ export function checkPlatform(
                     platformName: platform.name,
                     searchUrl: event.data?.searchResultsUrl || platform.searchUrl,
                     status: 'complete',
-                    available: event.data?.available || true,
+                    available: event.data?.available ?? true,
                     hotelsFound: event.data?.hotelsFound || 0,
                     message: event.data?.message,
                   });


### PR DESCRIPTION
## Summary

Replace `||` with `??` (nullish coalescing) for the `available` field in `checkPlatform()`.

## Problem

In `stay-scout-hub/src/lib/api/hotel-search.ts` line 116:

```ts
available: event.data?.available || true,
```

Because `||` treats `false` as falsy, this expression **always evaluates to `true`** — even when the API explicitly returns `available: false`. Hotels that are unavailable are incorrectly reported as available.

## Fix

```ts
available: event.data?.available ?? true,
```

The nullish coalescing operator (`??`) only falls back to `true` when the value is `null` or `undefined`, correctly preserving an explicit `false` from the API.

## Testing

Single-operator change with no side effects. The surrounding code already handles `null`/`undefined` via optional chaining (`event.data?.available`).
