### PR TITLE
Add Web Research Agent & Product Hunt Tracker n8n workflows

### DIFF
--- a/N8N_WorkFlows/Daily Product Hunt Tracker/Daily Product Hunt Tracker via Tinyfish.json
+++ b/N8N_WorkFlows/Daily Product Hunt Tracker/Daily Product Hunt Tracker via Tinyfish.json
@@ -1,0 +1,216 @@
+{
+  "name": "Daily Product Hunt Tracker — TinyFish + Telegram",
+  "nodes": [
+    {
+      "id": "schedule-trigger",
+      "name": "Schedule Trigger",
+      "type": "n8n-nodes-base.scheduleTrigger",
+      "position": [-740, -100],
+      "parameters": {
+        "rule": {
+          "interval": [
+            {
+              "triggerAtHour": 18
+            }
+          ]
+        }
+      },
+      "typeVersion": 1.2
+    },
+    {
+      "id": "tinyfish-extract",
+      "name": "TinyFish Extract",
+      "type": "n8n-nodes-tinyfish.tinyfish",
+      "position": [-400, -100],
+      "parameters": {
+        "url": "https://www.producthunt.com",
+        "goal": "Extract today's top 5 trending products from the homepage with their name, tagline, upvote count, tags, and product page URL.",
+        "options": {
+          "browserProfile": "stealth"
+        },
+        "operation": "runSse"
+      },
+      "credentials": {
+        "tinyfishApi": {
+          "id": "",
+          "name": "TinyFish Web Agent API account"
+        }
+      },
+      "typeVersion": 1
+    },
+    {
+      "id": "if-has-data",
+      "name": "If",
+      "type": "n8n-nodes-base.if",
+      "position": [-100, -100],
+      "parameters": {
+        "options": {
+          "looseTypeValidation": true
+        },
+        "conditions": {
+          "options": {
+            "version": 2,
+            "caseSensitive": true,
+            "typeValidation": "loose"
+          },
+          "combinator": "and",
+          "conditions": [
+            {
+              "id": "check-result",
+              "operator": {
+                "type": "string",
+                "operation": "notEmpty",
+                "singleValue": true
+              },
+              "leftValue": "={{ $json.resultJson }}",
+              "rightValue": ""
+            }
+          ]
+        }
+      },
+      "typeVersion": 2.2
+    },
+    {
+      "id": "format-agent",
+      "name": "Format Report",
+      "type": "@n8n/n8n-nodes-langchain.chainLlm",
+      "position": [180, -100],
+      "parameters": {
+        "text": "=Here is raw scraped data from Product Hunt. Format it into a clean Telegram message.\n\nData:\n{{ JSON.stringify($json.resultJson) }}",
+        "promptType": "define",
+        "batching": {}
+      },
+      "typeVersion": 1.7
+    },
+    {
+      "id": "openrouter-llm",
+      "name": "OpenRouter Chat Model",
+      "type": "@n8n/n8n-nodes-langchain.lmChatOpenRouter",
+      "position": [180, 100],
+      "parameters": {
+        "options": {
+          "systemMessage": "You format scraped product data into clean Telegram messages. Output ONLY the formatted message, nothing else.\n\nFormat:\n\ud83c\udfc6 Daily Product Hunt Trending Report\n\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\n\nThen for each product (ranked by upvotes, highest first):\n[medal emoji] [Name]  ([upvotes] upvotes)\n[Tagline]\n\ud83c\udff7 [comma-separated tags]\n\ud83d\udd17 [URL]\n\nUse \ud83e\udd47 \ud83e\udd48 \ud83e\udd49 for top 3, then #4 #5 etc.\n\nEnd with:\n\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\n\ud83d\udcc5 [today's date YYYY-MM-DD]\n\nDo not add any commentary. Just the formatted message."
+        }
+      },
+      "credentials": {
+        "openRouterApi": {
+          "id": "",
+          "name": "OpenRouter account"
+        }
+      },
+      "typeVersion": 1
+    },
+    {
+      "id": "telegram-send",
+      "name": "Telegram",
+      "type": "n8n-nodes-base.telegram",
+      "position": [440, -100],
+      "parameters": {
+        "text": "={{ $json.text }}",
+        "chatId": "YOUR_CHAT_ID",
+        "additionalFields": {}
+      },
+      "credentials": {
+        "telegramApi": {
+          "id": "",
+          "name": ""
+        }
+      },
+      "typeVersion": 1.2
+    },
+    {
+      "id": "sticky-main",
+      "name": "Sticky Note",
+      "type": "n8n-nodes-base.stickyNote",
+      "position": [-1400, -260],
+      "parameters": {
+        "color": 5,
+        "width": 700,
+        "height": 900,
+        "content": "\ud83c\udfc6 Daily Product Hunt Tracker with AI Formatting\nScrapes Product Hunt daily using TinyFish Web Agent, formats with AI, sends to Telegram.\n\n\ud83e\udded How It Works:\n\ud83d\udd54 Schedule Trigger \u2014 Runs daily at 6PM\n\ud83c\udfc6 TinyFish Web Agent \u2014 Scrapes top 5 products (stealth mode, SSE streaming)\n\ud83d\udd00 IF Node \u2014 Checks if data was returned\n\ud83e\udd16 AI Format \u2014 OpenRouter LLM formats the raw data into a clean report\n\ud83d\udcf2 Telegram \u2014 Sends the formatted report to your chat\n\n\u2705 Why this approach:\n- TinyFish goal is simple plain English \u2014 no rigid schema\n- AI handles any JSON structure \u2014 no brittle key matching\n- Clean, consistent Telegram output every time\n\n\ud83d\udd27 Requirements:\n\u2705 TinyFish API Key (https://agent.tinyfish.ai/api-keys)\n\u2705 OpenRouter API Key (https://openrouter.ai/keys)\n\u2705 Telegram Bot Token & Chat ID\n\n\ud83d\udee0 Customization:\n- Change URL and goal to scrape any site\n- Swap Telegram for Discord, Slack, email, or Notion\n- Change the AI system prompt to format differently"
+      },
+      "typeVersion": 1
+    },
+    {
+      "id": "sticky-trigger",
+      "name": "Sticky Note1",
+      "type": "n8n-nodes-base.stickyNote",
+      "position": [-840, -260],
+      "parameters": {
+        "width": 260,
+        "height": 420,
+        "content": "Scheduled Trigger"
+      },
+      "typeVersion": 1
+    },
+    {
+      "id": "sticky-tinyfish",
+      "name": "Sticky Note2",
+      "type": "n8n-nodes-base.stickyNote",
+      "position": [-500, -260],
+      "parameters": {
+        "color": 3,
+        "width": 320,
+        "height": 420,
+        "content": "TinyFish Web Agent\nSimple English goal. No schema needed."
+      },
+      "typeVersion": 1
+    },
+    {
+      "id": "sticky-result",
+      "name": "Sticky Note3",
+      "type": "n8n-nodes-base.stickyNote",
+      "position": [-160, -260],
+      "parameters": {
+        "color": 5,
+        "width": 560,
+        "height": 420,
+        "content": "AI Format & Send to Telegram"
+      },
+      "typeVersion": 1
+    }
+  ],
+  "connections": {
+    "Schedule Trigger": {
+      "main": [
+        [
+          { "node": "TinyFish Extract", "type": "main", "index": 0 }
+        ]
+      ]
+    },
+    "TinyFish Extract": {
+      "main": [
+        [
+          { "node": "If", "type": "main", "index": 0 }
+        ]
+      ]
+    },
+    "If": {
+      "main": [
+        [
+          { "node": "Format Report", "type": "main", "index": 0 }
+        ],
+        []
+      ]
+    },
+    "Format Report": {
+      "main": [
+        [
+          { "node": "Telegram", "type": "main", "index": 0 }
+        ]
+      ]
+    },
+    "OpenRouter Chat Model": {
+      "ai_languageModel": [
+        [
+          { "node": "Format Report", "type": "ai_languageModel", "index": 0 }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1"
+  },
+  "active": false,
+  "pinData": {}
+}

--- a/N8N_WorkFlows/Daily Product Hunt Tracker/README.md
+++ b/N8N_WorkFlows/Daily Product Hunt Tracker/README.md
@@ -1,0 +1,222 @@
+# Daily Product Hunt Tracker (n8n Workflow) — Setup & Run Guide
+
+Get a daily Telegram message with the top 5 trending products on Product Hunt, automatically scraped and formatted by AI.
+
+No APIs to parse, no brittle selectors — just tell TinyFish what you want in plain English, and an LLM formats it into a clean report.
+
+---
+
+## What you get
+
+Every day at 6 PM, a message like this lands in your Telegram:
+
+```
+🏆 Daily Product Hunt Trending Report
+━━━━━━━━━━━━━━━━━━━━━━━
+
+🥇 CoolApp  (842 upvotes)
+AI-powered workflow builder for teams
+🏷 Productivity, AI, No-Code
+🔗 https://www.producthunt.com/posts/coolapp
+
+🥈 FastDB  (631 upvotes)
+The database that scales itself
+🏷 Developer Tools, Database, Infrastructure
+🔗 https://www.producthunt.com/posts/fastdb
+
+...
+
+━━━━━━━━━━━━━━━━━━━━━━━
+📅 2026-03-11
+```
+
+---
+
+## How it works
+
+```
+Schedule Trigger (daily at 6 PM)
+  |
+  v
+TinyFish Extract (scrapes Product Hunt homepage, stealth + SSE)
+  |
+  v
+IF Node (checks if data was returned)
+  |
+  v
+Format Report (OpenRouter LLM formats raw data into Telegram message)
+  |
+  v
+Telegram (sends the formatted report to your chat)
+```
+
+1. **Schedule Trigger** fires daily at 6 PM (configurable)
+2. **TinyFish** visits `producthunt.com` in stealth mode and extracts the top 5 products — name, tagline, upvotes, tags, and URL
+3. **IF node** checks the scrape returned data (skips if empty)
+4. **OpenRouter LLM** takes the raw JSON and formats it into a clean, emoji-rich Telegram message
+5. **Telegram node** sends the message to your chat or group
+
+---
+
+## Prerequisites
+
+### API keys you need
+
+| Service | What for | Get it at |
+|---------|----------|-----------|
+| **TinyFish** | Web scraping | [agent.tinyfish.ai/api-keys](https://agent.tinyfish.ai/api-keys) |
+| **OpenRouter** | LLM formatting | [openrouter.ai/keys](https://openrouter.ai/keys) |
+| **Telegram** | Message delivery | Talk to [@BotFather](https://t.me/BotFather) on Telegram |
+
+### Software
+
+- **n8n** (Desktop, Docker, or Cloud)
+- **n8n-nodes-tinyfish** community node
+
+---
+
+## 1) Install & open n8n
+
+### Option A — n8n Desktop
+
+1. Download and install n8n Desktop
+2. Open it — runs at `http://localhost:5678`
+
+### Option B — Docker
+
+```bash
+docker run -it --rm \
+  -p 5678:5678 \
+  -v ~/.n8n:/home/node/.n8n \
+  n8nio/n8n
+```
+
+---
+
+## 2) Install the TinyFish community node
+
+1. In n8n, go to **Settings > Community Nodes**
+2. Click **Install**
+3. Enter: `n8n-nodes-tinyfish`
+4. Install and restart n8n if prompted
+
+---
+
+## 3) Import the workflow
+
+1. In n8n, click **Workflows > Import from file**
+2. Select `Daily Product Hunt Tracker via Tinyfish.json`
+3. Click **Save**
+
+You should see these nodes on the canvas:
+- **Schedule Trigger**
+- **TinyFish Extract**
+- **If** (data check)
+- **Format Report** (LLM chain) + **OpenRouter Chat Model**
+- **Telegram**
+
+---
+
+## 4) Set up credentials
+
+### 4.1 TinyFish
+
+1. **Credentials > New > TinyFish Web Agent**
+2. Paste your TinyFish API key
+3. Save and assign to the **TinyFish Extract** node
+
+### 4.2 OpenRouter
+
+1. **Credentials > New > OpenRouter**
+2. Paste your OpenRouter API key
+3. Save and assign to the **OpenRouter Chat Model** node
+
+### 4.3 Telegram Bot
+
+#### Create a bot
+
+1. Open Telegram and search for **@BotFather**
+2. Send `/newbot` and follow the prompts
+3. Copy the **bot token** BotFather gives you
+
+#### Get your Chat ID
+
+1. Start a chat with your new bot (send it any message)
+2. Visit `https://api.telegram.org/bot<YOUR_BOT_TOKEN>/getUpdates` in your browser
+3. Find `"chat":{"id":123456789}` — that number is your Chat ID
+
+> For group chats: add the bot to the group, send a message, then check `getUpdates`. Group chat IDs are negative numbers.
+
+#### Configure in n8n
+
+1. **Credentials > New > Telegram API**
+2. Paste your bot token
+3. Save and assign to the **Telegram** node
+4. Open the **Telegram** node and replace `YOUR_CHAT_ID` with your actual Chat ID
+
+---
+
+## 5) Running the workflow
+
+### Test run (immediate)
+
+1. Open the workflow
+2. Click **Execute workflow**
+3. Watch TinyFish scrape Product Hunt, the LLM format the data, and Telegram send the message
+4. Check your Telegram — you should have a report
+
+### Activate for daily runs
+
+1. Toggle the **Active** switch in the top right
+2. The workflow will now run automatically every day at 6 PM
+
+> To change the time: open the **Schedule Trigger** node and adjust `triggerAtHour`.
+
+---
+
+## Customization ideas
+
+- **Change the schedule**: Run every 12 hours, every Monday, or on a cron expression
+- **Scrape a different site**: Change the URL and goal in TinyFish — works with any website
+- **Swap the output**: Replace Telegram with Discord (webhook), Slack, email, Notion, or Google Sheets
+- **Track more products**: Change the goal to "top 10" instead of "top 5"
+- **Add filtering**: Add a Code node after TinyFish to filter by category, minimum upvotes, etc.
+- **Change the LLM**: Swap the OpenRouter model — any model works for formatting
+
+---
+
+## Troubleshooting
+
+### No Telegram message received
+
+- Make sure you started a conversation with the bot first (send it any message)
+- Verify the Chat ID is correct — revisit the `getUpdates` URL
+- For group chats, make sure the bot has permission to send messages
+
+### TinyFish returns empty data
+
+- Product Hunt may have changed their layout — try adjusting the goal text
+- Check your TinyFish API key and remaining credits
+- Try running manually to see the raw output
+
+### LLM formatting looks wrong
+
+- The AI system prompt defines the exact format — edit it in the **OpenRouter Chat Model** node
+- If products are out of order, add "ranked by upvotes, highest first" to the prompt
+
+### Schedule not firing
+
+- Make sure the workflow is toggled **Active**
+- Check that your n8n instance is running at the scheduled time (Docker containers that stop won't trigger)
+
+---
+
+## Quick checklist before first run
+
+- [ ] Workflow imported
+- [ ] TinyFish credential added and assigned
+- [ ] OpenRouter credential added and assigned
+- [ ] Telegram bot created via @BotFather
+- [ ] Chat ID obtained and set in the Telegram node
+- [ ] Test execution succeeds
+- [ ] Workflow toggled Active for daily runs

--- a/N8N_WorkFlows/Web Research Agent/README.md
+++ b/N8N_WorkFlows/Web Research Agent/README.md
@@ -1,0 +1,199 @@
+# Web Research Agent (n8n Workflow) — Setup & Run Guide
+
+Chat with an AI agent that scrapes any website and gives you a summarized report, saved automatically to Notion.
+
+Ask it things like:
+- "What do people on Reddit think about Arc browser?"
+- "Find pricing for Linear vs Jira vs Asana"
+- "What are the top complaints about Notion on Reddit?"
+
+The agent decides where to look, scrapes the page with TinyFish, analyzes the results, and saves a clean report to your Notion workspace.
+
+---
+
+## How it works
+
+```
+You (chat message)
+  |
+  v
+Web Agent (LangChain AI Agent)
+  |-- uses OpenRouter (Claude Haiku 4.5) for reasoning
+  |-- uses TinyFish Web Agent tool for live web scraping
+  |
+  v
+Create Notion Report (saves output as a new Notion page)
+```
+
+1. **You ask a question** in the n8n chat UI
+2. **The AI agent decides** the best URL and extraction goal based on your question
+   - For Reddit questions, it searches `old.reddit.com`
+   - For anything else, it constructs the right URL (pricing pages, review sites, docs, etc.)
+3. **TinyFish scrapes the page** in stealth mode and returns the raw content
+4. **The agent analyzes** the scraped data and produces a concise summary
+5. **A Notion page is created** with the full report, titled with your query and the date
+
+---
+
+## Prerequisites
+
+### Accounts / API keys you need
+
+| Service | What for | Get it at |
+|---------|----------|-----------|
+| **TinyFish** | Web scraping agent | [agent.tinyfish.ai/api-keys](https://agent.tinyfish.ai/api-keys) |
+| **OpenRouter** | LLM access (Claude Haiku 4.5) | [openrouter.ai/keys](https://openrouter.ai/keys) |
+| **Notion** | Report storage | [notion.so/my-integrations](https://www.notion.so/my-integrations) |
+
+### Software
+
+- **n8n** (Desktop, Docker, or Cloud) — see [n8n docs](https://docs.n8n.io/) if you need help installing
+- **n8n-nodes-tinyfish** community node (installed inside n8n)
+
+---
+
+## 1) Install & open n8n
+
+### Option A — n8n Desktop (easiest)
+
+1. Download and install n8n Desktop
+2. Open it — n8n runs at `http://localhost:5678`
+
+### Option B — Docker
+
+```bash
+docker run -it --rm \
+  -p 5678:5678 \
+  -v ~/.n8n:/home/node/.n8n \
+  n8nio/n8n
+```
+
+Then open `http://localhost:5678`.
+
+---
+
+## 2) Install the TinyFish community node
+
+1. In n8n, go to **Settings > Community Nodes**
+2. Click **Install**
+3. Enter: `n8n-nodes-tinyfish`
+4. Install and restart n8n if prompted
+
+---
+
+## 3) Import the workflow
+
+1. In n8n, click **Workflows > Import from file**
+2. Select `Web Research Agent via Tinyfish.json`
+3. Click **Save**
+
+You should see 4 nodes on the canvas:
+- **When chat message received** (trigger)
+- **Web Agent** (LangChain AI agent)
+- **OpenRouter Chat Model** + **TinyFish Web Agent** (connected as sub-nodes)
+- **Create Notion Report** (output)
+
+---
+
+## 4) Set up credentials
+
+### 4.1 TinyFish
+
+1. Go to **Credentials > New**
+2. Search for **TinyFish Web Agent**
+3. Paste your TinyFish API key
+4. Save
+5. Open the workflow and assign this credential to the **TinyFish Web Agent** node
+
+### 4.2 OpenRouter
+
+1. **Credentials > New**
+2. Search for **OpenRouter**
+3. Paste your OpenRouter API key
+4. Save
+5. Assign to the **OpenRouter Chat Model** node
+
+> The workflow defaults to `anthropic/claude-haiku-4.5`. You can change the model in the node settings — OpenRouter supports hundreds of models.
+
+### 4.3 Notion
+
+1. Go to [notion.so/my-integrations](https://www.notion.so/my-integrations)
+2. Click **New integration**
+3. Give it a name (e.g., "n8n Web Research")
+4. Copy the **Internal Integration Secret**
+5. In Notion, open the parent page where you want reports saved
+6. Click **...** > **Connections** > add your integration
+7. In n8n: **Credentials > New > Notion API**
+8. Paste the integration secret
+9. Save and assign to the **Create Notion Report** node
+10. Update the **Page ID** in the node to point to your own Notion page
+
+---
+
+## 5) Running the workflow
+
+1. Open the workflow in n8n
+2. Click **Execute workflow** (or toggle **Active** to keep it running)
+3. The n8n chat panel opens — type your question:
+
+```
+What do people on Reddit think about Cursor IDE?
+```
+
+4. The agent will:
+   - Decide to search Reddit for "Cursor IDE"
+   - Call TinyFish to scrape the search results
+   - Summarize the findings
+   - Save a report to Notion
+
+5. You'll see the response in the chat and a new page in your Notion workspace
+
+---
+
+## Example queries
+
+| Query | What happens |
+|-------|-------------|
+| "What does Reddit think about Supabase vs Firebase?" | Scrapes Reddit search, summarizes community sentiment |
+| "Find pricing for Vercel Pro vs Netlify Pro" | Visits pricing pages and compares plans |
+| "What are common complaints about Slack on Reddit?" | Searches Reddit for Slack complaints, categorizes themes |
+| "Summarize the top posts on Hacker News right now" | Scrapes Hacker News front page |
+
+---
+
+## Customization ideas
+
+- **Change the LLM**: Swap `anthropic/claude-haiku-4.5` for any model on OpenRouter (GPT-4o, Llama, Mistral, etc.)
+- **Change the output**: Replace the Notion node with Slack, Google Sheets, email, or any other n8n node
+- **Add memory**: Attach an n8n memory node to the agent for multi-turn conversations
+- **Adjust the system prompt**: Edit the Web Agent's system message to change behavior, output format, or target sites
+
+---
+
+## Troubleshooting
+
+### "TinyFish returned no data"
+
+- The site may be blocking scraping — try a different URL or query
+- Check your TinyFish API key is valid and has remaining credits
+
+### Notion page not created
+
+- Make sure your integration is connected to the parent page in Notion
+- Verify the Page ID in the **Create Notion Report** node matches your workspace
+
+### OpenRouter errors
+
+- Check your API key and account balance at [openrouter.ai](https://openrouter.ai)
+- Some models may have rate limits — try a different model if one fails
+
+---
+
+## Quick checklist before first run
+
+- [ ] Workflow imported
+- [ ] TinyFish credential added and assigned
+- [ ] OpenRouter credential added and assigned
+- [ ] Notion integration created and connected to parent page
+- [ ] Notion Page ID updated in the Create Notion Report node
+- [ ] Test with a simple query like "What is TinyFish?"

--- a/N8N_WorkFlows/Web Research Agent/Web Research Agent via Tinyfish.json
+++ b/N8N_WorkFlows/Web Research Agent/Web Research Agent via Tinyfish.json
@@ -1,0 +1,182 @@
+{
+  "nodes": [
+    {
+      "parameters": {
+        "options": {}
+      },
+      "id": "6b956bb9-d6c3-46dc-abf0-3b253aef99b5",
+      "name": "When chat message received",
+      "type": "@n8n/n8n-nodes-langchain.chatTrigger",
+      "typeVersion": 1.1,
+      "position": [
+        2944,
+        256
+      ],
+      "webhookId": "reddit-consensus-chat"
+    },
+    {
+      "parameters": {
+        "model": "anthropic/claude-haiku-4.5",
+        "options": {}
+      },
+      "id": "50c633c7-8347-4e38-b20e-708393ab8cb6",
+      "name": "OpenRouter Chat Model",
+      "type": "@n8n/n8n-nodes-langchain.lmChatOpenRouter",
+      "typeVersion": 1,
+      "position": [
+        3088,
+        480
+      ],
+      "credentials": {
+        "openRouterApi": {
+          "id": "93xqbFvgDLszbEx2",
+          "name": "OpenRouter account"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "pageId": {
+          "__rl": true,
+          "value": "https://www.notion.so/Reports-32066186caec802abbaef57607a62f9b?source=copy_link",
+          "mode": "url"
+        },
+        "title": "=Report — {{ $('When chat message received').item.json.chatInput }} — {{ new Date().toISOString().split('T')[0] }}",
+        "blockUi": {
+          "blockValues": [
+            {
+              "richText": true,
+              "text": {
+                "text": [
+                  {
+                    "text": "={{ $json.output }}",
+                    "annotationUi": {}
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        "options": {}
+      },
+      "id": "d71b9fd1-0cc1-4308-b6fb-377dd7daf769",
+      "name": "Create Notion Report",
+      "type": "n8n-nodes-base.notion",
+      "typeVersion": 2.2,
+      "position": [
+        3440,
+        256
+      ],
+      "credentials": {
+        "notionApi": {
+          "id": "zy8vYCBko9zNEyFW",
+          "name": "Notion account"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "content": "# Web Research Agent (TinyFish Web Agent)\n\nChat with an AI agent that scrapes any website and gives you a summarized report.\n\n## How It Works\n1. **You ask** — \"What do people think about [topic]?\" or \"Find pricing for [product]\"\n2. **Agent scrapes** — TinyFish Web Agent browses the relevant site with stealth mode\n3. **Agent analyzes** — OpenRouter LLM synthesizes the findings\n4. **Saved** — Creates a Notion page with the full report\n\n## Setup\n1. **TinyFish API Key** — Get at https://agent.tinyfish.ai/api-keys\n2. **OpenRouter API Key** — Get at https://openrouter.ai/keys\n3. **Notion** — Create an internal integration at notion.so/my-integrations, connect a parent page\n4. Connect all credentials and test with the chat!",
+        "height": 680,
+        "width": 760
+      },
+      "id": "30881dd3-5d01-4f5e-8576-ffde9aee9d94",
+      "name": "Sticky Note",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [
+        2096,
+        16
+      ]
+    },
+    {
+      "parameters": {
+        "url": "={{ /*n8n-auto-generated-fromAI-override*/ $fromAI('URL', ``, 'string') }}",
+        "goal": "={{ /*n8n-auto-generated-fromAI-override*/ $fromAI('Goal', ``, 'string') }}",
+        "options": {
+          "browserProfile": "stealth"
+        }
+      },
+      "type": "n8n-nodes-tinyfish.tinyfishTool",
+      "typeVersion": 1,
+      "position": [
+        3392,
+        512
+      ],
+      "id": "3f136c27-1d85-457c-8ae5-d40f909df960",
+      "name": "TinyFish Web Agent1",
+      "credentials": {
+        "tinyfishApi": {
+          "id": "mbrt8uD2ZV0tqtAh",
+          "name": "TinyFish Web Agent account"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "options": {
+          "systemMessage": "You are an intelligent web research analyst. When the user asks you to find\n  opinions, consensus, reviews, or information on any topic:\n\n  1. Analyze the user's message and decide the best URL and goal to pass to\n  the TinyFish Web Agent tool.\n     - For Reddit: use\n  https://old.reddit.com/search/?q=YOUR_SEARCH_TERMS&sort=relevance&t=month\n     - For any other website: construct the appropriate URL based on what the\n  user asks.\n     - You decide the search terms, URL, and extraction goal based on the\n  user's intent.\n  2. In the goal, tell TinyFish exactly what to extract (titles, content,\n  links, prices, reviews — whatever is relevant).\n  3. Once you receive the scraped data, analyze it and give the user a clear,\n  useful summary.\n  4. Format your response in plain text only. No markdown, no bold, no\n  headers, no bullet symbols. Use line breaks and spacing to organize\n  sections. Label sections like TOPIC:, SUMMARY:, KEY THEMES:, NOTABLE\n  SOURCES:, DISSENTING VIEWS:.\n\n  Always use stealth browser profile when calling TinyFish.\n  If the scrape returns no data, tell the user and suggest refining their\n  query.\n\n  IMPORTANT: Keep your entire response under 2000 characters. Be concise. Do\n  NOT use any markdown formatting — no asterisks, no hashtags, no dashes for\n  bullets."
+        }
+      },
+      "id": "98efb616-3fe2-47b6-a986-f8d0bf907eb9",
+      "name": "Web Agent",
+      "type": "@n8n/n8n-nodes-langchain.agent",
+      "typeVersion": 1.7,
+      "position": [
+        3184,
+        256
+      ]
+    }
+  ],
+  "connections": {
+    "When chat message received": {
+      "main": [
+        [
+          {
+            "node": "Web Agent",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "OpenRouter Chat Model": {
+      "ai_languageModel": [
+        [
+          {
+            "node": "Web Agent",
+            "type": "ai_languageModel",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "TinyFish Web Agent1": {
+      "ai_tool": [
+        [
+          {
+            "node": "Web Agent",
+            "type": "ai_tool",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Web Agent": {
+      "main": [
+        [
+          {
+            "node": "Create Notion Report",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "pinData": {},
+  "meta": {
+    "templateCredsSetupCompleted": true,
+    "instanceId": "93ae535be561fa96a49e2c0436c691a052a1b8a9118da8ac44dd7791f8b097b9"
+  }
+}

--- a/README.md
+++ b/README.md
@@ -70,18 +70,39 @@ Each folder in this repo is a standalone project. Dive in to see how to solve re
 |--------|-------------|
 | [anime-watch-hub](./anime-watch-hub) | Helps you find sites to read/watch your favorite manga/anime for free |
 | [bestbet](./bestbet) | Sports betting odds comparison tool |
+| [code-reference-finder](./code-reference-finder) | AI-powered code snippet analyzer that finds real-world usage examples from GitHub and Stack Overflow |
 | [competitor-analysis](./competitor-analysis) | Live competitive pricing intelligence dashboard |
+| [competitor-scout-cli](./competitor-scout-cli) | Natural language CLI tool for researching competitor feature decisions across multiple websites |
+| [concept-discovery-system](./concept-discovery-system) | Project idea validator that discovers similar existing projects across GitHub, Dev.to, and Stack Overflow |
 | [fast-qa](./fast-qa) | No-code QA testing platform with parallel test execution and live browser previews |
+| [game-buying-guide](./game-buying-guide) | Video game buying decision tool comparing pricing and deals across 10 gaming platforms in parallel |
+| [lego-hunter](./lego-hunter) | Global inventory search tool finding rare Lego sets across 15+ retailers with price and availability analysis |
 | [loan-decision-copilot](./loan-decision-copilot) | AI-powered loan comparison tool across banks and regions |
 | [logistics-sentry](./logistics-sentry) | Logistics intelligence platform for port congestion and carrier risk tracking |
 | [Manga-Availability-Finder](./Manga-Availability-Finder) | Searches multiple reading platforms for manga/webtoon availability |
 | [openbox-deals](./openbox-deals) | Real-time open-box and refurbished deal aggregator across 8 retailers |
 | [research-sentry](./research-sentry) | Voice-first academic research co-pilot scanning ArXiv, PubMed, and more |
+| [restaurant-comparison-tool](./restaurant-comparison-tool) | Pre-visit restaurant safety intelligence tool analyzing Google Maps reviews, menus, and allergen signals |
 | [scholarship-finder](./scholarship-finder) | AI-powered scholarship discovery system pulling live data from official websites |
+| [silicon-signal](./silicon-signal) | Semiconductor supply chain tracker for lifecycle, availability, and lead-time signals |
 | [stay-scout-hub](./stay-scout-hub) | Searches across all sites for places to stay when traveling for conventions or events |
 | [summer-school-finder](./summer-school-finder) | Discover and compare summer school programs from universities around the world |
+| [tenders-finder](./tenders-finder) | AI-powered Singapore government tender discovery tool scraping multiple tender portals in parallel |
 | [tinyskills](./tinyskills) | Multi-source AI skill guide generator |
-| [silicon-signal](./silicon-signal) | Semiconductor supply chain tracker for lifecycle, availability, and lead-time signals |
+| [tutor-finder](./tutor-finder) | AI-powered tutor discovery platform for competitive exams across multiple platforms |
+| [viet-bike-scout](./viet-bike-scout) | Motorbike rental price comparison tool across Vietnamese cities using parallel browser agents |
+| [waifu-deal-sniper](./waifu-deal-sniper) | Discord bot for anime figure collectors finding discounted pre-owned figures from AmiAmi, Mercari, and Solaris Japan |
+| [wing-command](./wing-command) | Chicken wing tracker using AI-powered scraping to find the best wings near you by flavor preference |
+
+### n8n Workflows
+
+Pre-built n8n workflows using TinyFish — import the JSON and go.
+
+| Workflow | Description |
+|----------|-------------|
+| [Competitor Scout](./N8N_WorkFlows/Competitor%20Scout%20CLI) | Research competitor feature decisions with OpenAI planning and TinyFish evidence collection |
+| [Web Research Agent](./N8N_WorkFlows/Web%20Research%20Agent) | Chatbot that scrapes any website with TinyFish and saves summarized reports to Notion |
+| [Daily Product Hunt Tracker](./N8N_WorkFlows/Daily%20Product%20Hunt%20Tracker) | Scheduled workflow delivering daily top 5 trending Product Hunt products to Telegram |
 
 > More recipes added weekly!
 


### PR DESCRIPTION
## Summary
- Add **Web Research Agent** n8n workflow: chat-based web scraper using TinyFish + OpenRouter (Claude Haiku 4.5) with automatic Notion report export
- Add **Daily Product Hunt Tracker** n8n workflow: scheduled daily scrape of top 5 trending Product Hunt products, AI-formatted and sent to Telegram
- Update main README table from 14 to **25 recipes** (added all missing projects) and add a new **n8n Workflows** section linking all 3 workflows

## New files
- `N8N_WorkFlows/Web Research Agent/Web Research Agent via Tinyfish.json`
- `N8N_WorkFlows/Web Research Agent/README.md`
- `N8N_WorkFlows/Daily Product Hunt Tracker/Daily Product Hunt Tracker via Tinyfish.json`
- `N8N_WorkFlows/Daily Product Hunt Tracker/README.md`

## Test plan
- [ ] Import each workflow JSON into n8n and verify it loads correctly
- [ ] Verify all README links in the main table resolve to the correct directories
- [ ] Verify n8n Workflows section links work with URL-encoded spaces