### PR TITLE
Update code-reference-finder to Gemini 3.1 Flash Lite

### DIFF
--- a/code-reference-finder/src/lib/constants.ts
+++ b/code-reference-finder/src/lib/constants.ts
@@ -3,7 +3,7 @@ export const OPENROUTER_API_URL = 'https://openrouter.ai/api/v1/chat/completions
 export const GITHUB_API_URL = 'https://api.github.com';
 export const STACKEXCHANGE_API_URL = 'https://api.stackexchange.com/2.3';
 
-export const OPENROUTER_MODEL = 'google/gemini-2.0-flash-001';
+export const OPENROUTER_MODEL = 'google/gemini-3.1-flash-lite-preview';
 export const OPENROUTER_TEMPERATURE = 0.2;
 
 export const MAX_AGENTS = 10;


### PR DESCRIPTION
## Summary
- Upgrade OpenRouter model from `google/gemini-2.0-flash-001` to `google/gemini-3.1-flash-lite-preview`
- 2.5x faster time-to-first-token, 45% faster output, and ~2x cheaper

## Test plan
- [ ] Run the code-reference-finder app and verify code analysis still works correctly with the new model