### PR TITLE
fix(openbox-deals): update API field names from camelCase to snake_case

### DIFF
--- a/openbox-deals/README.md
+++ b/openbox-deals/README.md
@@ -88,17 +88,17 @@ payload = {
 
 async with session.post(MINO_API_URL, json=payload, headers=headers) as response:
     async for chunk in response.content.iter_any():
-        # SSE events: streamingUrl, status updates, resultJson
+        # SSE events: streaming_url, status updates, result_json
         pass
 ```
 
 ### SSE Event Flow
 
 ```
-data: {"streamingUrl":"https://tf-xxx.lax1-tinyfish.unikraft.app/stream/0"}
+data: {"streaming_url":"https://tf-xxx.lax1-tinyfish.unikraft.app/stream/0"}
 data: {"type":"STATUS","message":"Navigating to Best Buy..."}
 data: {"type":"STATUS","message":"Extracting Open-Box products..."}
-data: {"type":"COMPLETE","resultJson":[{"name":"iPhone 16","sale_price":"$604.99",...}]}
+data: {"type":"COMPLETE","result_json":[{"name":"iPhone 16","sale_price":"$604.99",...}]}
 ```
 
 ## 📁 Project Structure

--- a/openbox-deals/app/main.py
+++ b/openbox-deals/app/main.py
@@ -448,19 +448,19 @@ async def search_live(
                                     try:
                                         event = json.loads(line[6:])
                                         
-                                        if event.get("streamingUrl") and not streaming_url_sent:
+                                        if event.get("streaming_url") and not streaming_url_sent:
                                             await event_queue.put({
                                                 "type": "session_start",
                                                 "site": site_key,
                                                 "site_name": site_config["name"],
-                                                "streamingUrl": event["streamingUrl"],
+                                                "streaming_url": event["streaming_url"],
                                                 "searchUrl": search_url
                                             })
                                             streaming_url_sent = True
                                         
                                         # Extract result from various fields
-                                        if event.get("resultJson"):
-                                            result_data = event["resultJson"]
+                                        if event.get("result_json"):
+                                            result_data = event["result_json"]
                                         elif event.get("result"):
                                             result_data = event["result"]
                                         elif event.get("data") and isinstance(event.get("data"), (list, dict)):
@@ -484,8 +484,8 @@ async def search_live(
                         if buffer.strip().startswith("data: "):
                             try:
                                 event = json.loads(buffer.strip()[6:])
-                                if event.get("resultJson"):
-                                    result_data = event["resultJson"]
+                                if event.get("result_json"):
+                                    result_data = event["result_json"]
                                 elif event.get("result"):
                                     result_data = event["result"]
                             except:

--- a/openbox-deals/static/index.html
+++ b/openbox-deals/static/index.html
@@ -893,8 +893,8 @@
                     const content = document.getElementById(`content-${event.site}`);
                     const status = document.getElementById(`status-${event.site}`);
                     
-                    if (content && event.streamingUrl) {
-                        content.innerHTML = `<iframe src="${event.streamingUrl}" allow="autoplay"></iframe>`;
+                    if (content && event.streaming_url) {
+                        content.innerHTML = `<iframe src="${event.streaming_url}" allow="autoplay"></iframe>`;
                     }
                     
                     if (status) {


### PR DESCRIPTION
## Summary
- Updated TinyFish API response field names in openbox-deals to match the new snake_case format
- `streamingUrl` → `streaming_url`
- `resultJson` → `result_json`
- Changes applied across `app/main.py`, `static/index.html`, and `README.md`

**Note:** wing-command and waifu-deal-sniper were also checked — they already use snake_case or don't reference these fields, so no changes were needed.
