### PR TITLE
security: pin axios to exact safe version 1.13.4 (supply chain fix)

### DIFF
--- a/wing-command/package.json
+++ b/wing-command/package.json
@@ -21,7 +21,7 @@
     "@tanstack/react-query": "^5.51.1",
     "@upstash/redis": "^1.34.0",
     "autoprefixer": "^10.4.19",
-    "axios": "^1.7.2",
+    "axios": "1.13.4",
     "canvas-confetti": "^1.9.3",
     "clsx": "^2.1.1",
     "date-fns": "^3.6.0",


### PR DESCRIPTION
## Summary

Pins `axios` in `wing-command/package.json` from the loose range `^1.7.2` to the exact version `1.13.4`.

- `axios@1.14.1` was published March 30–31, 2026 with a Remote Access Trojan (postinstall hook delivering a RAT that beacons to C2 every 60s)
- `^1.7.2` allows resolving up to any `1.x.y`, including the compromised `1.14.1`
- The lockfile is already resolved to `1.13.4` (safe) — no lockfile change needed
- Exact pin prevents any future `npm install` from pulling a different version

Ref: [ENG-13585](https://linear.app/tinyfish/issue/ENG-13585) / [ENG-13581](https://linear.app/tinyfish/issue/ENG-13581)

## Test plan
- [ ] `npm install` in `wing-command/` resolves axios to exactly `1.13.4`
- [ ] No axios `1.14.1` appears in the generated lockfile