### PR TITLE
feat: add 7 new TinyFish skills

### DIFF
--- a/skills/freelance-gig-finder/SKILL.md
+++ b/skills/freelance-gig-finder/SKILL.md
@@ -1,0 +1,224 @@
+---
+name: freelance-gig-finder
+description: Find fresh freelance and contract opportunities across multiple platforms for any skill set. Use this skill when a user asks "find me freelance React jobs", "Upwork gigs for Python developers", "freelance work posted this week", "contract jobs for designers", "find me remote freelance opportunities for [skill]", "I'm looking for freelance work", "what freelance gigs are available for [skill]", or any request to find paid freelance or contract work online.
+---
+
+# Freelance Gig Finder
+
+Search Upwork, Contra, We Work Remotely, Freelancer, and Toptal simultaneously for fresh freelance and contract opportunities matching your skill set — filtered to recent postings so you're not looking at stale listings.
+
+## Pre-flight Check (REQUIRED)
+
+Before making any TinyFish call, always run BOTH checks:
+
+**1. CLI installed?**
+```bash
+which tinyfish && tinyfish --version || echo "TINYFISH_CLI_NOT_INSTALLED"
+```
+
+If not installed, stop and tell the user:
+> Install the TinyFish CLI: `npm install -g @tiny-fish/cli`
+
+**2. Authenticated?**
+```bash
+tinyfish auth status
+```
+
+If not authenticated, stop and tell the user:
+> You need a TinyFish API key. Get one at: https://agent.tinyfish.ai/api-keys
+>
+> Then authenticate:
+> ```
+> tinyfish auth login
+> ```
+
+Do NOT proceed until both checks pass.
+
+---
+
+## Step 1 — Gather inputs
+
+You need:
+- **Skill or role** — e.g. `React developer`, `Python`, `UI/UX designer`, `copywriter`, `DevOps`, `mobile developer`
+- **Budget preference** (optional) — e.g. `hourly`, `fixed price`, `$50+/hr`
+- **Recency** (optional) — default to listings posted in the last 7 days
+
+If skill is not provided, ask before proceeding.
+
+---
+
+## Step 2 — Parallel search
+
+Fire all agents simultaneously.
+
+```bash
+# Agent 1 — Upwork
+tinyfish agent run \
+  --url "https://www.upwork.com/nx/search/jobs/?sort=recency&q={SKILL_ENCODED}" \
+  "You are on Upwork job search results for '{SKILL}', sorted by most recent.
+   Extract the first 8 visible job listings.
+   For each listing extract:
+   - title
+   - client description snippet (what they need)
+   - budget (hourly rate range or fixed price if shown)
+   - posted time (e.g. '2 hours ago', 'yesterday')
+   - required skills listed
+   - job type (hourly/fixed)
+   - direct URL to the listing
+   STRICT RULES:
+   - Do NOT click any listing
+   - Read only what is visible in the search result cards
+   - Only include listings posted within the last 7 days
+   - Maximum 8 listings then stop
+   Return JSON array: [{title, description, budget, posted, skills: [], job_type, url}]" \
+  --sync > /tmp/fg_upwork.json &
+
+# Agent 2 — Contra
+tinyfish agent run \
+  --url "https://contra.com/opportunities?query={SKILL_ENCODED}&sort=recent" \
+  "You are on Contra job listings for '{SKILL}', sorted by newest.
+   Extract the first 8 visible job listings.
+   For each listing extract:
+   - title
+   - client/company name
+   - description snippet
+   - budget or rate (if shown)
+   - posted time
+   - required skills
+   - direct URL
+   STRICT RULES:
+   - Do NOT click any listing
+   - Read only what is visible in the listing cards
+   - Maximum 8 listings then stop
+   - If no results found, return {found: false}
+   Return JSON array: [{title, client, description, budget, posted, skills: [], url}]" \
+  --sync > /tmp/fg_contra.json &
+
+# Agent 3 — We Work Remotely
+tinyfish agent run \
+  --url "https://weworkremotely.com/remote-jobs/search?term={SKILL_ENCODED}" \
+  "You are on We Work Remotely job search results for '{SKILL}'.
+   Extract the first 8 visible job listings.
+   For each listing extract:
+   - title
+   - company name
+   - category (e.g. Front-End, Back-End, Design, etc.)
+   - posted date
+   - direct URL to the listing
+   STRICT RULES:
+   - Do NOT click any listing
+   - Read only what is visible in the search results
+   - Maximum 8 listings then stop
+   - If no results, return {found: false}
+   Return JSON array: [{title, company, category, posted, url}]" \
+  --sync > /tmp/fg_wwr.json &
+
+# Agent 4 — Freelancer.com
+tinyfish agent run \
+  --url "https://www.freelancer.com/jobs/?keyword={SKILL_ENCODED}" \
+  "You are on Freelancer.com job listings for '{SKILL}'.
+   Extract the first 8 visible job listings.
+   For each listing extract:
+   - title
+   - budget range (fixed or hourly)
+   - number of bids (if shown)
+   - posted time
+   - required skills listed
+   - direct URL
+   STRICT RULES:
+   - Do NOT click any listing
+   - Read only what is visible in the listing cards
+   - Maximum 8 listings then stop
+   Return JSON array: [{title, budget, bids, posted, skills: [], url}]" \
+  --sync > /tmp/fg_freelancer.json &
+
+# Agent 5 — LinkedIn (contract/freelance filter)
+tinyfish agent run \
+  --url "https://www.linkedin.com/jobs/search/?keywords={SKILL_ENCODED}&f_JT=C%2CF&f_WT=2&sortBy=DD" \
+  "You are on LinkedIn job search results for '{SKILL}' filtered to Contract and Freelance jobs, remote, sorted by most recent.
+   Extract the first 8 visible job listings.
+   For each listing extract:
+   - title
+   - company name
+   - location or remote status
+   - posted time
+   - salary or rate if shown
+   - direct URL
+   STRICT RULES:
+   - Do NOT click any listing
+   - Read only what is visible in the job cards
+   - Maximum 8 listings then stop
+   Return JSON array: [{title, company, location, posted, salary, url}]" \
+  --sync > /tmp/fg_linkedin.json &
+
+wait
+
+echo "=== UPWORK ===" && cat /tmp/fg_upwork.json
+echo "=== CONTRA ===" && cat /tmp/fg_contra.json
+echo "=== WWR ===" && cat /tmp/fg_wwr.json
+echo "=== FREELANCER ===" && cat /tmp/fg_freelancer.json
+echo "=== LINKEDIN ===" && cat /tmp/fg_linkedin.json
+```
+
+**Before running**, replace:
+- `{SKILL}` — e.g. `React developer`
+- `{SKILL_ENCODED}` — URL-encoded e.g. `React%20developer`
+
+---
+
+## Step 3 — Filter and present
+
+From all results, deduplicate any listings that appear on multiple platforms and filter to only show listings posted within the last 7 days. Sort by recency — newest first.
+
+```
+## Freelance Gigs — {SKILL}
+*Scraped live from Upwork · Contra · We Work Remotely · Freelancer · LinkedIn*
+*{N} listings found · Posted in the last 7 days · {date}*
+
+---
+
+### 🔥 Fresh Listings
+
+#### {Title}
+**Platform:** {platform} · **Posted:** {posted}
+**Budget:** {budget or rate}
+**Skills:** {skills}
+{description snippet}
+🔗 {url}
+
+---
+
+#### {Title}
+[same structure]
+
+---
+[up to 15 listings total, sorted by most recent]
+
+---
+
+### 📊 Quick Summary
+
+| Platform | Listings Found | Avg Budget |
+|---|---|---|
+| Upwork | {n} | {avg} |
+| Contra | {n} | - |
+| We Work Remotely | {n} | - |
+| Freelancer | {n} | {avg} |
+| LinkedIn | {n} | {avg} |
+
+---
+
+### 💡 Tips for These Listings
+{1-2 sentences of context — e.g. "Upwork has the most volume but high competition. Contra listings tend to be higher quality clients at better rates. LinkedIn contract roles are typically longer engagements."}
+```
+
+---
+
+## Edge Cases
+
+- **Upwork requires login to view listings** — extract whatever is visible before the gate, note the limitation
+- **No listings found for skill** — try alternative phrasings (e.g. "React" → "React.js", "frontend developer"; "Python" → "Python developer", "Django")
+- **Very niche skill** — We Work Remotely and LinkedIn may have the richest results; Upwork/Freelancer tend to have more volume for common skills
+- **User wants a specific budget range** — add budget filters to Upwork and Freelancer URLs before running
+- **User is in a specific country** — note that Upwork and Freelancer are global but some listings are location-restricted; LinkedIn can be filtered by country
+- **All platforms return few results** — suggest the user check back in a few days or broaden the skill (e.g. "React" instead of "React Native")

--- a/skills/hackathon-finder/SKILL.md
+++ b/skills/hackathon-finder/SKILL.md
@@ -1,0 +1,307 @@
+---
+name: hackathon-finder
+description: Find hackathons tailored to your tech profile and location by searching Devpost, Luma, Partiful, MLH, and Eventbrite. Use this skill when a user asks "find me a hackathon", "are there any hackathons near me", "what hackathons are coming up", "I want to compete in a hackathon", "find hackathons I could win", "upcoming hackathons in [city]", "online hackathons for [skill/tech]", or any request to discover hackathon opportunities.
+---
+
+# Hackathon Finder
+
+Build a tech profile from everything known about you, then search Devpost, Luma, Partiful, MLH, and Eventbrite for upcoming hackathons — local or online — that match your stack and give you the best shot at winning.
+
+## Pre-flight Check (REQUIRED)
+
+Before making any TinyFish call, always run BOTH checks:
+
+**1. CLI installed?**
+```bash
+which tinyfish && tinyfish --version || echo "TINYFISH_CLI_NOT_INSTALLED"
+```
+
+If not installed, stop and tell the user:
+> Install the TinyFish CLI: `npm install -g @tiny-fish/cli`
+
+**2. Authenticated?**
+```bash
+tinyfish auth status
+```
+
+If not authenticated, stop and tell the user:
+> You need a TinyFish API key. Get one at: https://agent.tinyfish.ai/api-keys
+>
+> Then authenticate:
+> ```
+> tinyfish auth login
+> ```
+
+Do NOT proceed until both checks pass.
+
+---
+
+## Step 1 — Build the user's tech profile
+
+Before searching for anything, build a picture of who you're helping. Draw from everything available in the current conversation and session context:
+
+- Languages and frameworks mentioned or used (e.g. React, Python, Rust)
+- Projects described or worked on
+- Areas of interest expressed (e.g. AI/ML, Web3, hardware, design)
+- Skill level signals (beginner, experienced, specialist)
+- Any past hackathon experience mentioned
+
+Summarize this as a brief internal profile:
+
+```
+Tech profile:
+- Primary languages: {e.g. Python, TypeScript}
+- Frameworks / tools: {e.g. React, FastAPI, LangChain}
+- Interest areas: {e.g. AI, developer tools, consumer apps}
+- Skill level: {beginner / intermediate / experienced}
+- Past hackathons: {yes/no, any wins?}
+```
+
+If very little is known, ask one quick question:
+> "What do you usually build with? (e.g. languages, frameworks, or areas like AI, web, mobile)"
+
+---
+
+## Step 2 — Ask for location and format preference
+
+Ask the user two things before searching:
+
+```
+Two quick questions:
+
+1. **Where are you based?** (city and country — e.g. "Singapore", "London, UK", "Austin, TX")
+   Or if you prefer online-only hackathons, just say "online".
+
+2. **What are you optimizing for?**
+   - 🏆 Best chance of winning (match your stack to the theme)
+   - 🌍 Biggest / most prestigious (large prize pools, well-known sponsors)
+   - 🤝 Best for networking / meeting people
+   - 🧪 Most interesting theme (something you'd genuinely enjoy building)
+```
+
+Wait for the user's response before proceeding.
+
+---
+
+## Step 3 — Parallel hackathon search
+
+Fire all agents simultaneously based on the user's location and tech profile.
+
+```bash
+# Agent 1 — Devpost (largest hackathon aggregator)
+tinyfish agent run \
+  --url "https://devpost.com/hackathons?challenge_type=online&status=upcoming" \
+  "You are on Devpost's upcoming hackathons page.
+   Find hackathons relevant to these technologies: {TECH_KEYWORDS}.
+   For each relevant hackathon extract:
+   - name
+   - theme or focus area
+   - prize pool (total or top prize)
+   - registration deadline
+   - hackathon dates
+   - online or in-person (and location if in-person)
+   - direct URL
+   - sponsor companies (if shown)
+   STRICT RULES:
+   - Do NOT click into any hackathon page
+   - Read only what is visible in the listing cards
+   - Only include hackathons with future dates
+   - Maximum 10 listings then stop
+   Return JSON array: [{name, theme, prize_pool, deadline, dates, format, location, url, sponsors: []}]" \
+  --sync > /tmp/hf_devpost.json &
+
+# Agent 2 — Devpost (in-person / local, if user specified a city)
+tinyfish agent run \
+  --url "https://devpost.com/hackathons?challenge_type=in-person&status=upcoming&search={LOCATION_ENCODED}" \
+  "You are on Devpost's upcoming in-person hackathons page filtered to {LOCATION}.
+   Find hackathons in or near {LOCATION}.
+   For each extract:
+   - name
+   - theme or focus area
+   - prize pool
+   - registration deadline
+   - hackathon dates
+   - exact location (city, venue if shown)
+   - direct URL
+   - sponsor companies
+   STRICT RULES:
+   - Do NOT click into any hackathon page
+   - Maximum 8 listings then stop
+   - Only include hackathons with future dates
+   Return JSON array: [{name, theme, prize_pool, deadline, dates, location, url, sponsors: []}]" \
+  --sync > /tmp/hf_devpost_local.json &
+
+# Agent 3 — MLH (Major League Hacking)
+tinyfish agent run \
+  --url "https://mlh.io/seasons/2026/events" \
+  "You are on the MLH (Major League Hacking) events page for the current season.
+   Find upcoming hackathons, especially any in or near {LOCATION} or online.
+   For each event extract:
+   - name
+   - date
+   - location (city or online)
+   - direct URL
+   - any theme or focus if shown
+   STRICT RULES:
+   - Do NOT click any event
+   - Read only the visible event cards
+   - Maximum 10 events then stop
+   - Only future events
+   Return JSON array: [{name, date, location, url, theme}]" \
+  --sync > /tmp/hf_mlh.json &
+
+# Agent 4 — Luma
+tinyfish agent run \
+  --url "https://lu.ma/discover?q=hackathon+{LOCATION_ENCODED}" \
+  "You are on Luma event discovery searching for hackathons near {LOCATION}.
+   Find upcoming hackathon events.
+   For each event extract:
+   - name
+   - date and time
+   - location (in-person address or online)
+   - host / organizer
+   - short description or theme
+   - direct URL
+   STRICT RULES:
+   - Do NOT click any event
+   - Read only what is visible in the event cards
+   - Maximum 8 events then stop
+   - Only future events
+   - If no hackathons found, return {found: false}
+   Return JSON array: [{name, date, location, host, description, url}]" \
+  --sync > /tmp/hf_luma.json &
+
+# Agent 5 — Devpost tech-specific search
+tinyfish agent run \
+  --url "https://devpost.com/hackathons?search={TECH_KEYWORD_ENCODED}&status=upcoming" \
+  "You are on Devpost searching for hackathons related to {PRIMARY_TECH}.
+   Find hackathons that specifically feature {PRIMARY_TECH} as a theme, sponsor, or required technology.
+   For each extract:
+   - name
+   - theme
+   - prize pool
+   - deadline
+   - dates
+   - format (online/in-person)
+   - direct URL
+   - why it's relevant to {PRIMARY_TECH}
+   STRICT RULES:
+   - Do NOT click into any hackathon
+   - Maximum 8 listings then stop
+   - Only future hackathons
+   Return JSON array: [{name, theme, prize_pool, deadline, dates, format, url, relevance}]" \
+  --sync > /tmp/hf_devpost_tech.json &
+
+# Agent 6 — Eventbrite
+tinyfish agent run \
+  --url "https://www.eventbrite.com/d/{LOCATION_SLUG}/hackathon/" \
+  "You are on Eventbrite searching for hackathon events in {LOCATION}.
+   Find upcoming hackathon events.
+   For each event extract:
+   - name
+   - date
+   - location (venue or online)
+   - price / ticket cost (free or paid)
+   - organizer
+   - short description
+   - direct URL
+   STRICT RULES:
+   - Do NOT click any event
+   - Read only what is visible in the event cards
+   - Maximum 8 events then stop
+   - Only future events
+   Return JSON array: [{name, date, location, price, organizer, description, url}]" \
+  --sync > /tmp/hf_eventbrite.json &
+
+wait
+
+echo "=== DEVPOST ONLINE ===" && cat /tmp/hf_devpost.json
+echo "=== DEVPOST LOCAL ===" && cat /tmp/hf_devpost_local.json
+echo "=== MLH ===" && cat /tmp/hf_mlh.json
+echo "=== LUMA ===" && cat /tmp/hf_luma.json
+echo "=== DEVPOST TECH ===" && cat /tmp/hf_devpost_tech.json
+echo "=== EVENTBRITE ===" && cat /tmp/hf_eventbrite.json
+```
+
+**Before running**, replace:
+- `{LOCATION}` — e.g. `Singapore`, `London`
+- `{LOCATION_ENCODED}` — URL-encoded e.g. `Singapore`
+- `{LOCATION_SLUG}` — Eventbrite format e.g. `singapore--sg`
+- `{TECH_KEYWORDS}` — comma-separated e.g. `AI, React, Python`
+- `{TECH_KEYWORD_ENCODED}` — primary tech URL-encoded e.g. `artificial-intelligence`
+- `{PRIMARY_TECH}` — single best-match technology e.g. `AI/ML`
+
+---
+
+## Step 4 — Score and rank by fit
+
+For each hackathon found, score it against the user's tech profile and stated goal:
+
+**Fit score (0-10):**
+- Theme matches user's primary tech area: +4
+- Sponsor uses tech the user knows: +2
+- Prize pool / prestige matches stated goal: +2
+- Location matches preference: +2
+
+Present hackathons ranked by fit score, with the win-probability assessment front and center.
+
+---
+
+## Output format
+
+```
+## Hackathons for You — {LOCATION} · {date}
+
+*Based on your profile: {PRIMARY_LANGUAGES} · {INTEREST_AREAS}*
+*Searched: Devpost · MLH · Luma · Eventbrite*
+
+---
+
+### 🏆 Best Matches (Highest Win Potential)
+
+#### {Hackathon Name}
+**📅** {dates} · **📍** {location or online}
+**💰** Prize: {prize_pool} · **⏰** Register by: {deadline}
+**🎯 Why you'd win:** {1-2 sentences on why this fits the user's stack and the theme}
+**Sponsors:** {sponsors}
+🔗 {url}
+
+---
+
+#### {Hackathon Name}
+[same structure]
+
+---
+
+### 🌍 Also Worth Considering
+
+[remaining hackathons, shorter format]
+
+- **{name}** — {date} · {location} · {prize} · {url}
+
+---
+
+### 📊 Summary
+
+| Hackathon | Format | Date | Prize | Fit |
+|---|---|---|---|---|
+| {name} | Online/Local | {date} | {prize} | ⭐⭐⭐⭐⭐ |
+
+---
+
+### 💡 Strategy Tips
+{1-3 targeted tips based on the user's profile and the hackathons found}
+- e.g. "The {hackathon} has an AI track with no strong competition in the LLM tooling space — right in your wheelhouse"
+- e.g. "For MLH events, solo Python projects with clean demos tend to score well with judges"
+```
+
+---
+
+## Edge Cases
+
+- **User is online-only** — skip Devpost local, Luma local, and Eventbrite local agents; focus on Devpost online and MLH
+- **No hackathons found in the city** — broaden to country, then to online, and note the broadening
+- **User has no clear tech profile** — skip the fit scoring, present all hackathons by date and let the user choose
+- **User has won hackathons before** — note this and suggest larger or more competitive events; skip beginner-friendly ones
+- **User is a beginner** — prioritize beginner-friendly or first-timer hackathons; flag events that explicitly welcome new participants
+- **No upcoming hackathons found** — suggest checking back closer to major seasons (September-November and January-March tend to be peak hackathon periods)

--- a/skills/leetcode-coach/SKILL.md
+++ b/skills/leetcode-coach/SKILL.md
@@ -1,0 +1,328 @@
+---
+name: leetcode-coach
+description: Find and set up coding practice problems tailored to your weak areas, then create local files so you can solve them right away. Use this skill when a user wants to practice coding, asks for a LeetCode problem, says "give me a coding challenge", "I want to practice DSA", "help me prep for coding interviews", "find me a problem to solve", "I'm weak at dynamic programming", "quiz me on algorithms", or any request to practice coding with a specific language or topic focus.
+---
+
+# LeetCode Coach
+
+Find coding problems matched to your weak areas from LeetCode, HackerRank, and Codeforces — then set up local files so you can start solving immediately.
+
+## Pre-flight Check (REQUIRED)
+
+Before making any TinyFish call, always run BOTH checks:
+
+**1. CLI installed?**
+```bash
+which tinyfish && tinyfish --version || echo "TINYFISH_CLI_NOT_INSTALLED"
+```
+
+If not installed, stop and tell the user:
+> Install the TinyFish CLI: `npm install -g @tiny-fish/cli`
+
+**2. Authenticated?**
+```bash
+tinyfish auth status
+```
+
+If not authenticated, stop and tell the user:
+> You need a TinyFish API key. Get one at: https://agent.tinyfish.ai/api-keys
+>
+> Then authenticate:
+> ```
+> tinyfish auth login
+> ```
+
+Do NOT proceed until both checks pass.
+
+---
+
+## Step 1 — Gather inputs
+
+Ask for the following if not already provided:
+
+**Required:**
+- **Preferred language** — e.g. Python, JavaScript, Java, C++, Go, Rust
+
+**Optional (but improves results):**
+- **Weak areas / topics to focus on** — e.g. "dynamic programming", "graphs", "sliding window", "binary search", "recursion", "trees"
+- **Difficulty** — Easy / Medium / Hard (default: Medium)
+
+If the user isn't sure of their weak areas, ask:
+> "What topics do you find yourself getting stuck on, or want to get better at?"
+
+If they still aren't sure, default to: Arrays, Strings, and Hash Maps (the most commonly tested fundamentals).
+
+---
+
+## Step 2 — Find matching problems
+
+Fire parallel TinyFish agents across LeetCode, HackerRank, and Codeforces to find real problems matching the topic and difficulty.
+
+```bash
+# Agent 1 — LeetCode problem search
+tinyfish agent run \
+  --url "https://leetcode.com/problemset/?difficulty={DIFFICULTY}&topicSlugs={TOPIC_SLUG}" \
+  "You are on the LeetCode problem set page filtered by difficulty and topic.
+   Find 3 problems that match the topic: {TOPIC}.
+   For each problem extract:
+   - title
+   - difficulty (Easy/Medium/Hard)
+   - acceptance rate
+   - topic tags
+   - direct URL to the problem (e.g. https://leetcode.com/problems/two-sum/)
+   STRICT RULES:
+   - Do NOT click any problem to open it
+   - Read only the problem listing visible on this page
+   - Return exactly 3 problems, no more
+   - Skip premium-only problems (marked with a lock icon)
+   Return JSON array: [{title, difficulty, acceptance_rate, tags, url}]" \
+  --sync > /tmp/lc_leetcode.json &
+
+# Agent 2 — HackerRank problem search
+tinyfish agent run \
+  --url "https://www.hackerrank.com/domains/algorithms?filters%5Bsubdomains%5D%5B%5D={TOPIC_SLUG}" \
+  "You are on HackerRank's algorithms problem listing filtered by topic.
+   Find 2 problems that match the topic: {TOPIC} at {DIFFICULTY} level.
+   For each problem extract:
+   - title
+   - difficulty
+   - score/points
+   - topic tags
+   - direct URL to the problem
+   STRICT RULES:
+   - Do NOT click any problem
+   - Read only the visible listing
+   - Return up to 2 problems
+   - Skip problems requiring premium or contests
+   Return JSON array: [{title, difficulty, score, tags, url}]" \
+  --sync > /tmp/lc_hackerrank.json &
+
+# Agent 3 — Codeforces problem search
+tinyfish agent run \
+  --url "https://codeforces.com/problemset?tags={TOPIC_SLUG}" \
+  "You are on Codeforces problem set filtered by tag.
+   Find 2 problems matching the topic: {TOPIC} at approximately {DIFFICULTY} level
+   (Easy ≈ rating 800-1200, Medium ≈ 1300-1800, Hard ≈ 1900+).
+   For each problem extract:
+   - problem ID (e.g. 1A, 158B)
+   - title
+   - rating
+   - tags
+   - direct URL (e.g. https://codeforces.com/problemset/problem/1/A)
+   STRICT RULES:
+   - Do NOT click any problem
+   - Read only the visible listing
+   - Return up to 2 problems
+   Return JSON array: [{id, title, rating, tags, url}]" \
+  --sync > /tmp/lc_codeforces.json &
+
+wait
+
+echo "=== LEETCODE ===" && cat /tmp/lc_leetcode.json
+echo "=== HACKERRANK ===" && cat /tmp/lc_hackerrank.json
+echo "=== CODEFORCES ===" && cat /tmp/lc_codeforces.json
+```
+
+**Before running**, replace:
+- `{DIFFICULTY}` — Easy / Medium / Hard
+- `{TOPIC}` — human-readable topic e.g. `dynamic programming`
+- `{TOPIC_SLUG}` — URL-friendly e.g. `dynamic-programming`
+
+---
+
+## Step 3 — Present problem options
+
+From the results, pick the **3 best problems** across all sources. Prefer:
+1. LeetCode problems (widest community support, best editorial availability)
+2. Problems with clear descriptions visible from the listing
+3. Problems with acceptance rates between 30-60% for Medium difficulty
+
+Present them like this:
+
+```
+Here are 3 problems matched to your focus on **{TOPIC}** in **{LANGUAGE}**:
+
+**Option 1 — {Title}** ({difficulty}) · {source}
+Tags: {tags}
+Acceptance: {rate}
+🔗 {url}
+
+**Option 2 — {Title}** ({difficulty}) · {source}
+Tags: {tags}
+🔗 {url}
+
+**Option 3 — {Title}** ({difficulty}) · {source}
+Tags: {tags}
+🔗 {url}
+
+Which one do you want to tackle? (1, 2, or 3)
+```
+
+Wait for the user to choose a problem before proceeding.
+
+---
+
+## Step 3b — Ask how they want to solve it
+
+Once the user picks a problem, ask:
+
+```
+How do you want to solve it?
+
+1. **On the website** — I'll give you the direct link and you solve it in the browser
+2. **Locally** — I'll fetch the full problem and set up files on your machine so you can code in your editor
+
+(1 or 2)
+```
+
+**If they choose option 1 (website):**
+Give them the direct link to the problem and wish them luck:
+```
+Here you go: {problem_url}
+
+Good luck! Come back and paste your solution when you're done — I'll review it.
+```
+Stop here. Do not create any files.
+
+**If they choose option 2 (locally):**
+Continue to Step 4.
+
+---
+
+## Step 4 — Fetch the full problem
+
+Once the user picks, fetch the full problem description using TinyFish.
+
+```bash
+tinyfish agent run \
+  --url "{CHOSEN_PROBLEM_URL}" \
+  "You are on a coding problem page. Extract the complete problem details.
+   Extract:
+   - title
+   - difficulty
+   - full problem description (exactly as written — do not paraphrase)
+   - constraints (exact list)
+   - all example inputs and outputs with explanations
+   - topic tags
+   - any follow-up questions mentioned
+   STRICT RULES:
+   - Do NOT click any links
+   - Extract the complete description verbatim — do not shorten it
+   - If examples have visual diagrams described in text, include them
+   Return JSON: {title, difficulty, description, constraints: [], examples: [{input, output, explanation}], tags: [], followup}" \
+  --sync
+```
+
+---
+
+## Step 5 — Create local files
+
+Once you have the full problem, create these three files in the current working directory:
+
+### `problem.md`
+
+```markdown
+# {Problem Title}
+
+**Source:** {url}
+**Difficulty:** {difficulty}
+**Tags:** {tags}
+**Language:** {language}
+
+---
+
+## Problem
+
+{full problem description}
+
+## Constraints
+
+{constraints as bullet list}
+
+## Examples
+
+### Example 1
+**Input:** {input}
+**Output:** {output}
+**Explanation:** {explanation}
+
+### Example 2
+...
+
+---
+
+## Notes
+<!-- Add your approach notes here before coding -->
+```
+
+### `solution.{ext}`
+
+Create a starter file with the correct extension for the chosen language and a function signature scaffold. Use the appropriate extension:
+
+| Language | Extension | Starter |
+|----------|-----------|---------|
+| Python | `.py` | `def solution():` with docstring |
+| JavaScript | `.js` | `function solution() {}` with JSDoc |
+| TypeScript | `.ts` | typed function signature |
+| Java | `.java` | class + method scaffold |
+| C++ | `.cpp` | `#include` + function |
+| Go | `.go` | package + func |
+| Rust | `.rs` | `fn solution()` |
+
+Include a comment at the top:
+```
+// Problem: {title}
+// Source: {url}
+// Difficulty: {difficulty}
+// Your approach: (fill this in before coding)
+```
+
+Infer the function signature from the problem description if possible (e.g. if the problem says "given an array of integers, return..."). If unclear, use a generic starter.
+
+### `test_cases.md`
+
+```markdown
+# Test Cases — {Problem Title}
+
+## From the problem
+
+| # | Input | Expected Output |
+|---|-------|----------------|
+| 1 | {input} | {output} |
+| 2 | {input} | {output} |
+
+## Edge cases to consider
+<!-- Think about: empty input, single element, negative numbers, duplicates, max constraints -->
+- [ ] Empty input
+- [ ] Single element
+- [ ] Already sorted / already valid
+- [ ] Maximum constraint size
+```
+
+---
+
+## Step 6 — Brief the user
+
+Once the files are created, tell the user:
+
+```
+Files created:
+- problem.md     ← full problem description
+- solution.{ext} ← starter template in {language}
+- test_cases.md  ← sample test cases + edge case checklist
+
+Take your time and solve it. When you're done, paste your solution here and I'll review it — checking for correctness, edge cases, time complexity, and style.
+
+Good luck!
+```
+
+---
+
+## Edge Cases
+
+- **LeetCode returns no results for topic** — fall back to searching `https://leetcode.com/problemset/?search={TOPIC}` without the filter
+- **Problem URL is premium-only** — skip it and pick the next best option from the results
+- **User doesn't know their weak areas** — default to Arrays + Hash Maps (Medium), which covers the widest range of interview fundamentals
+- **User wants a specific problem by name** — skip Steps 2-3, go straight to fetching and creating files for that problem
+- **Codeforces returns nothing** — skip it silently, present options from LeetCode and HackerRank only
+- **User is a complete beginner** — suggest Easy difficulty and start with Two Sum (LeetCode #1) as a warm-up before moving to their topic of interest

--- a/skills/npm-package-comparator/SKILL.md
+++ b/skills/npm-package-comparator/SKILL.md
@@ -1,0 +1,232 @@
+---
+name: npm-package-comparator
+description: Compare two or more npm packages side by side using live data — downloads, bundle size, GitHub stars, last update, known vulnerabilities, and community sentiment. Use this skill when a user asks "zustand vs jotai vs redux", "compare react-query and swr", "which state management library should I use", "what's the difference between X and Y", "is X better than Y for my use case", "help me choose between these packages", or any request to compare npm packages or decide between JavaScript libraries.
+---
+
+# npm Package Comparator
+
+Compare any set of npm packages side by side using live data from npm, GitHub, Bundlephobia, and Snyk — then give a clear recommendation based on what you actually need.
+
+## Pre-flight Check (REQUIRED)
+
+Before making any TinyFish call, always run BOTH checks:
+
+**1. CLI installed?**
+```bash
+which tinyfish && tinyfish --version || echo "TINYFISH_CLI_NOT_INSTALLED"
+```
+
+If not installed, stop and tell the user:
+> Install the TinyFish CLI: `npm install -g @tiny-fish/cli`
+
+**2. Authenticated?**
+```bash
+tinyfish auth status
+```
+
+If not authenticated, stop and tell the user:
+> You need a TinyFish API key. Get one at: https://agent.tinyfish.ai/api-keys
+>
+> Then authenticate:
+> ```
+> tinyfish auth login
+> ```
+
+Do NOT proceed until both checks pass.
+
+---
+
+## Step 1 — Gather inputs
+
+You need:
+- **Package names** — 2 to 4 packages to compare (e.g. `zustand`, `jotai`, `redux`)
+- **Use case** (optional but improves recommendation) — e.g. "small React app", "large enterprise codebase", "need SSR support"
+
+If the user hasn't specified a use case, ask:
+> "What are you building with it? (e.g. small side project, large team codebase, performance-critical app)"
+
+If they don't know, proceed without it and give a general recommendation.
+
+---
+
+## Step 2 — Parallel data fetch
+
+For each package, fire agents across npm, GitHub, Bundlephobia, and Snyk simultaneously. Run ALL agents for ALL packages in parallel — one agent per package per source.
+
+```bash
+# ── For each PACKAGE, run all 4 agents in parallel ───────────
+
+# npm stats
+tinyfish agent run \
+  --url "https://www.npmjs.com/package/{PACKAGE}" \
+  "You are on the npm page for the package {PACKAGE}.
+   Extract:
+   - current version
+   - weekly downloads (exact number shown)
+   - total downloads if shown
+   - last publish date
+   - license
+   - number of dependencies
+   - TypeScript support (yes/no — check if types are listed)
+   - maintainers count
+   - repository URL
+   STRICT RULES:
+   - Do NOT click any links
+   - Read only what is visible on this page
+   - If a field is not shown, return null
+   Return JSON: {package, version, weekly_downloads, last_published, license, dependency_count, typescript_support, maintainer_count, repo_url}" \
+  --sync > /tmp/npm_{PACKAGE_SAFE}.json &
+
+# GitHub stats
+tinyfish agent run \
+  --url "https://github.com/{OWNER}/{REPO}" \
+  "You are on the GitHub repository page for {PACKAGE}.
+   Extract:
+   - star count
+   - fork count
+   - open issues count
+   - last commit date
+   - number of contributors (from sidebar or Insights)
+   - latest release tag and date
+   - whether the repo is actively maintained (check: last commit within 6 months)
+   STRICT RULES:
+   - Do NOT click any tabs or links
+   - Read only what is visible on the main repo page
+   Return JSON: {package, stars, forks, open_issues, last_commit, contributors, latest_release, latest_release_date, is_active}" \
+  --sync > /tmp/gh_{PACKAGE_SAFE}.json &
+
+# Bundle size
+tinyfish agent run \
+  --url "https://bundlephobia.com/package/{PACKAGE}" \
+  "You are on the Bundlephobia page for {PACKAGE}.
+   Extract:
+   - minified size (in KB)
+   - minified + gzipped size (in KB)
+   - download time on slow 3G (if shown)
+   - tree-shakeable (yes/no)
+   - side-effect free (yes/no)
+   STRICT RULES:
+   - Do NOT click any links
+   - Read only what is visible on this page
+   - If the page hasn't loaded sizes yet, note it
+   Return JSON: {package, minified_kb, gzipped_kb, tree_shakeable, side_effect_free}" \
+  --sync > /tmp/bp_{PACKAGE_SAFE}.json &
+
+# Known vulnerabilities
+tinyfish agent run \
+  --url "https://security.snyk.io/package/npm/{PACKAGE}" \
+  "You are on the Snyk security page for the npm package {PACKAGE}.
+   Extract:
+   - total number of known vulnerabilities
+   - number by severity: critical, high, medium, low
+   - most recent vulnerability title and date (if shown)
+   STRICT RULES:
+   - Do NOT click any vulnerability links
+   - Read only the summary visible on this page
+   - If the page shows 'no vulnerabilities', return {total: 0}
+   Return JSON: {package, total_vulns, critical, high, medium, low, latest_vuln_title, latest_vuln_date}" \
+  --sync > /tmp/snyk_{PACKAGE_SAFE}.json &
+
+# Repeat the above 4 agents for each additional package
+# All backgrounded with & — fire everything at once then:
+wait
+
+# Collect all results
+for p in {PACKAGE_LIST}; do
+  echo "=== $p ===" 
+  cat /tmp/npm_${p}.json
+  cat /tmp/gh_${p}.json
+  cat /tmp/bp_${p}.json
+  cat /tmp/snyk_${p}.json
+done
+```
+
+**Before running**, replace:
+- `{PACKAGE}` — exact npm package name e.g. `zustand`
+- `{PACKAGE_SAFE}` — safe filename version e.g. `zustand`
+- `{OWNER}/{REPO}` — GitHub repo e.g. `pmndrs/zustand`
+- `{PACKAGE_LIST}` — space-separated list of all packages
+
+Use your knowledge to find the correct GitHub repo for well-known packages. For unknown packages, check the `repository` field on their npm page first.
+
+---
+
+## Step 3 — Synthesize comparison
+
+Combine all data into a side-by-side comparison.
+
+```
+## Package Comparison: {PACKAGE_1} vs {PACKAGE_2} vs ...
+
+*Data fetched live — {date}*
+
+---
+
+### 📊 At a Glance
+
+| | {pkg1} | {pkg2} | {pkg3} |
+|---|---|---|---|
+| **Version** | {v} | {v} | {v} |
+| **Weekly Downloads** | {n} | {n} | {n} |
+| **GitHub Stars** | {n} | {n} | {n} |
+| **Bundle (gzipped)** | {n}kb | {n}kb | {n}kb |
+| **Tree-shakeable** | ✅/❌ | ✅/❌ | ✅/❌ |
+| **TypeScript** | ✅/❌ | ✅/❌ | ✅/❌ |
+| **Last Published** | {date} | {date} | {date} |
+| **Known Vulns** | {n} | {n} | {n} |
+| **License** | {l} | {l} | {l} |
+
+---
+
+### 📈 Popularity & Health
+
+{2-3 sentences comparing download trends, GitHub activity, and community size}
+
+---
+
+### 📦 Bundle Size
+
+{Comparison of bundle impact — important for frontend packages}
+{Flag if any package is significantly larger than alternatives}
+
+---
+
+### 🔒 Security
+
+{Note any packages with known vulnerabilities}
+{If all clean: "No known vulnerabilities found for any of these packages."}
+
+---
+
+### ⚙️ Maintenance
+
+{Compare last commit dates, contributor counts, release cadence}
+{Flag any package that looks abandoned (no commits in 12+ months)}
+
+---
+
+### 🎯 Recommendation
+
+{Use case}: {user's stated use case or "general use"}
+
+**Best pick: {PACKAGE}**
+
+{2-3 sentences explaining why this package wins for this use case, and what trade-offs you're making}
+
+**When to pick {PACKAGE_2} instead:**
+{1-2 sentences on when the runner-up is the better choice}
+
+**Avoid {PACKAGE_3} if:**
+{Any specific reasons to avoid a package in certain contexts}
+```
+
+---
+
+## Edge Cases
+
+- **Package not on npm** — check if it's a GitHub-only package and scrape the repo directly
+- **Bundlephobia doesn't have it** — note "bundle size unavailable" and skip that row
+- **GitHub repo not found from npm page** — search `https://github.com/search?q={PACKAGE}&type=repositories` to find the canonical repo
+- **One of the packages is deprecated** — flag it clearly at the top of the comparison: "⚠️ {package} is deprecated — the maintainers recommend {replacement}"
+- **Comparing more than 4 packages** — ask the user to narrow to their top 3, as more becomes hard to compare meaningfully
+- **Packages serve slightly different purposes** — note the distinction upfront before comparing (e.g. "react-query handles server state, zustand handles client state — you may actually need both")

--- a/skills/salary-market-scanner/SKILL.md
+++ b/skills/salary-market-scanner/SKILL.md
@@ -1,0 +1,222 @@
+---
+name: salary-market-scanner
+description: Scan live job boards and salary databases to find real-time compensation data for any role and location. Use this skill when a user asks "what's the going rate for a senior React engineer in London", "software engineer salary Singapore", "how much do ML engineers make", "what should I be earning as a [role]", "is my salary competitive", "what does [company] pay for [role]", "salary range for [job title] in [city]", or any request to find out what a role pays in a specific market.
+---
+
+# Salary Market Scanner
+
+Scrape live job boards and salary databases to find real compensation data for any role and location — not outdated surveys, but what companies are actually posting and paying right now.
+
+## Pre-flight Check (REQUIRED)
+
+Before making any TinyFish call, always run BOTH checks:
+
+**1. CLI installed?**
+```bash
+which tinyfish && tinyfish --version || echo "TINYFISH_CLI_NOT_INSTALLED"
+```
+
+If not installed, stop and tell the user:
+> Install the TinyFish CLI: `npm install -g @tiny-fish/cli`
+
+**2. Authenticated?**
+```bash
+tinyfish auth status
+```
+
+If not authenticated, stop and tell the user:
+> You need a TinyFish API key. Get one at: https://agent.tinyfish.ai/api-keys
+>
+> Then authenticate:
+> ```
+> tinyfish auth login
+> ```
+
+Do NOT proceed until both checks pass.
+
+---
+
+## Step 1 — Gather inputs
+
+You need:
+- **Job title / role** — e.g. `Senior Software Engineer`, `ML Engineer`, `Product Designer`, `DevOps Engineer`
+- **Location** — e.g. `London`, `Singapore`, `San Francisco`, `Remote`
+- **Years of experience** (optional) — e.g. `3-5 years`, `senior`, `entry level`
+- **Specific company** (optional) — if the user wants to know what a specific company pays
+
+If location is not provided, ask before proceeding. Salary data varies dramatically by market.
+
+---
+
+## Step 2 — Parallel salary scan
+
+Fire all agents simultaneously. Sources vary by location — include the most relevant ones.
+
+```bash
+# Agent 1 — Levels.fyi (best for tech roles, especially US/global big tech)
+tinyfish agent run \
+  --url "https://www.levels.fyi/t/{ROLE_SLUG}/?country={COUNTRY}" \
+  "You are on Levels.fyi showing compensation data for {ROLE} in {LOCATION}.
+   Extract:
+   - Median total compensation
+   - Base salary range (p25 to p75)
+   - Bonus range
+   - Stock/equity range (if shown)
+   - Sample size (number of data points)
+   - Top companies listed and their compensation ranges
+   - Any breakdown by years of experience if visible
+   STRICT RULES:
+   - Do NOT click any company or individual entry
+   - Read only the aggregate data visible on the page
+   - If no data for this location, return {found: false, reason: 'no data for location'}
+   Return JSON: {found: bool, median_total, base_p25, base_p75, bonus_range, equity_range, sample_size, top_companies: [{company, base, total}], yoe_breakdown: []}" \
+  --sync > /tmp/sal_levels.json &
+
+# Agent 2 — Glassdoor salaries
+tinyfish agent run \
+  --url "https://www.google.com/search?q=glassdoor+{ROLE_ENCODED}+salary+{LOCATION_ENCODED}+site:glassdoor.com/Salaries" \
+  "You are on Google search results. Find the most relevant Glassdoor salary page for {ROLE} in {LOCATION} and click it.
+   On the Glassdoor salary page extract:
+   - Median base salary
+   - Salary range (low to high)
+   - Number of salary reports
+   - Additional pay (bonus, profit sharing) range if shown
+   - Top companies paying for this role if listed
+   STRICT RULES:
+   - Click only the first Glassdoor salary result
+   - Do NOT click any other links after landing on Glassdoor
+   - Read only the aggregate salary data visible on the page
+   - If the page asks you to sign in, extract whatever is visible before the gate
+   Return JSON: {median_base, salary_low, salary_high, report_count, additional_pay_range, top_companies: [{company, salary}]}" \
+  --sync > /tmp/sal_glassdoor.json &
+
+# Agent 3 — LinkedIn Jobs (extract posted salary ranges from active listings)
+tinyfish agent run \
+  --url "https://www.linkedin.com/jobs/search/?keywords={ROLE_ENCODED}&location={LOCATION_ENCODED}&f_SB2=1&sortBy=DD" \
+  "You are on LinkedIn job search results for {ROLE} in {LOCATION}, filtered to show salary information, sorted by date.
+   For each job listing card visible on the page:
+   - Click into the listing to open the job detail panel on the right
+   - Look for the salary range in the detail panel (often shown near the top under the job title)
+   - Extract: job title, company name, salary range, employment type
+   - Go back to the listing and repeat for the next one
+   STRICT RULES:
+   - Only extract listings that show an explicit salary — skip those without
+   - Maximum 10 listings then stop
+   - Do NOT navigate away from the search results page
+   Return JSON array: [{title, company, salary_range, employment_type}]" \
+  --sync > /tmp/sal_linkedin.json &
+
+# Agent 4 — Indeed salaries
+tinyfish agent run \
+  --url "https://www.indeed.com/career/{ROLE_INDEED}/salaries?from=top_sb&l={LOCATION_ENCODED}" \
+  "You are on Indeed's salary page for {ROLE} in {LOCATION}.
+   Extract:
+   - Average base salary
+   - Salary range (low to high)
+   - Number of salary reports
+   - Salary by experience level (if shown: entry, mid, senior)
+   - Top paying companies for this role (if listed)
+   STRICT RULES:
+   - Do NOT click any links
+   - Read only the aggregate data on this page
+   Return JSON: {average_salary, salary_low, salary_high, report_count, by_experience: [{level, salary}], top_companies: [{company, salary}]}" \
+  --sync > /tmp/sal_indeed.json &
+
+wait
+
+echo "=== LEVELS ===" && cat /tmp/sal_levels.json
+echo "=== GLASSDOOR ===" && cat /tmp/sal_glassdoor.json
+echo "=== LINKEDIN ===" && cat /tmp/sal_linkedin.json
+echo "=== INDEED ===" && cat /tmp/sal_indeed.json
+```
+
+**Before running**, replace:
+- `{ROLE}` — human-readable e.g. `Senior Software Engineer`
+- `{ROLE_ENCODED}` — URL-encoded e.g. `Senior%20Software%20Engineer`
+- `{ROLE_SLUG}` — Levels.fyi slug e.g. `software-engineer`
+- `{ROLE_INDEED}` — Indeed format e.g. `software-engineer`
+- `{LOCATION}` — e.g. `London`, `Singapore`
+- `{LOCATION_ENCODED}` — URL-encoded e.g. `London%2C%20England`
+- `{COUNTRY}` — country code for Levels.fyi e.g. `GB`, `SG`, `US`
+
+---
+
+## Step 3 — Synthesize the market picture
+
+Combine data from all sources and calculate aggregate ranges.
+
+```
+## Salary Market Report — {ROLE} · {LOCATION}
+
+*Live data scraped from Levels.fyi, Glassdoor, LinkedIn, and Indeed*
+*{date} · Based on {N} total data points*
+
+---
+
+### 💰 Compensation Summary
+
+| | Low | Median | High |
+|---|---|---|---|
+| **Base Salary** | {low} | {median} | {high} |
+| **Total Comp** (incl. bonus/equity) | {low} | {median} | {high} |
+
+> All figures in {CURRENCY}. "Total comp" includes base + annual bonus + annualized equity where data is available.
+
+---
+
+### 📊 By Experience Level
+
+| Level | Typical Base |
+|---|---|
+| Entry (0-2 yrs) | {range} |
+| Mid (3-5 yrs) | {range} |
+| Senior (6+ yrs) | {range} |
+| Staff / Principal | {range} |
+
+*(Skip levels where no data was found)*
+
+---
+
+### 🏢 What Companies Are Posting
+
+From active LinkedIn job listings with disclosed salaries:
+
+| Company | Role | Posted Range |
+|---|---|---|
+| {company} | {title} | {range} |
+
+---
+
+### 🏆 Top Paying Companies
+
+*(From Levels.fyi and Glassdoor)*
+| Company | Median Base | Median Total |
+|---|---|---|
+| {company} | {base} | {total} |
+
+---
+
+### 📈 Market Signals
+
+{2-3 sentences on what the data says about this market — is it competitive, is there a wide spread, are companies being transparent about pay?}
+
+---
+
+### 🔍 Data Sources
+- Levels.fyi: {sample_size} data points / not found
+- Glassdoor: {report_count} salary reports / not found  
+- LinkedIn: {N} active listings with disclosed salaries
+- Indeed: {report_count} salary reports / not found
+```
+
+---
+
+## Edge Cases
+
+- **Levels.fyi has no data for this location** — lean on Glassdoor and Indeed; note that Levels.fyi skews toward US big tech
+- **Role title is unusual** — try common variations (e.g. "ML Engineer" → "Machine Learning Engineer", "AI Engineer")
+- **Location is a small city** — broaden to the country or nearest major city and note the change
+- **Remote role** — scrape for both the user's country and the US market, present both (remote jobs often use US pay bands)
+- **Non-tech role** — skip Levels.fyi (tech-only), rely on Glassdoor and Indeed
+- **Salary shown in different currencies** — normalize to the local currency and note conversion rate used
+- **User is asking if their salary is competitive** — after presenting the data, ask what they're currently earning and give a direct assessment

--- a/skills/stalk-my-interviewer/SKILL.md
+++ b/skills/stalk-my-interviewer/SKILL.md
@@ -1,0 +1,255 @@
+---
+name: stalk-my-interviewer
+description: Research an interviewer online before a meeting using parallel TinyFish agents and return a structured prep report. Use this skill when a user says "research my interviewer", "I have an interview with [name] at [company]", "stalk my interviewer", "find out about [person] before my interview", "who is my interviewer", "prepare for interview with [name]", "look up my interviewer", or any request to learn about a specific person before meeting them professionally.
+---
+
+# Stalk My Interviewer
+
+Deploy parallel TinyFish agents to research an interviewer across LinkedIn, GitHub, Twitter/X, news, and conference platforms — then synthesize a structured prep report so you walk in knowing exactly who you're talking to.
+
+## Pre-flight Check (REQUIRED)
+
+Before making any TinyFish call, always run BOTH checks:
+
+**1. CLI installed?**
+```bash
+which tinyfish && tinyfish --version || echo "TINYFISH_CLI_NOT_INSTALLED"
+```
+
+If not installed, stop and tell the user:
+> Install the TinyFish CLI: `npm install -g @tiny-fish/cli`
+
+**2. Authenticated?**
+```bash
+tinyfish auth status
+```
+
+If not authenticated, stop and tell the user:
+> You need a TinyFish API key. Get one at: https://agent.tinyfish.ai/api-keys
+>
+> Then authenticate:
+> ```
+> tinyfish auth login
+> ```
+
+Do NOT proceed until both checks pass.
+
+---
+
+## Step 1 — Gather inputs
+
+You need:
+- **Interviewer's full name** — e.g. "Sarah Chen"
+- **Company** — e.g. "Stripe", "Anthropic", "Linear"
+- **Role you're interviewing for** (optional but improves output) — e.g. "Senior Software Engineer"
+
+If any are missing, ask before proceeding. If the name is very common (e.g. "John Smith"), ask for company and role to disambiguate before searching.
+
+---
+
+## Step 2 — Parallel research
+
+Fire all agents simultaneously. Every agent searches a different surface — run them all at once using `&` + `wait`.
+
+```bash
+# Agent 1 — LinkedIn
+tinyfish agent run \
+  --url "https://www.linkedin.com/search/results/people/?keywords={FULL_NAME_ENCODED}+{COMPANY_ENCODED}" \
+  "You are on a LinkedIn people search results page. Find the profile for {FULL_NAME} who works or worked at {COMPANY}.
+   Click the most relevant result.
+   On their profile extract:
+   - Current job title and company
+   - Previous roles (last 3 positions: title, company, duration)
+   - Education (degrees, institutions)
+   - Skills listed (top 10)
+   - Summary / About section (if visible)
+   - How long they have been at {COMPANY}
+   STRICT RULES:
+   - Click only the most relevant profile result — do not browse multiple profiles
+   - Do NOT scroll more than twice on the profile page
+   - If the page asks you to log in, extract whatever is visible before the gate and return it
+   - Do NOT click any other links
+   Return JSON: {name, current_title, current_company, tenure_at_company, previous_roles: [{title, company, duration}], education: [{degree, institution}], skills: [], summary}" \
+  --sync > /tmp/smi_linkedin.json &
+
+# Agent 2 — GitHub (relevant if role is technical)
+tinyfish agent run \
+  --url "https://github.com/search?q={FULL_NAME_ENCODED}+{COMPANY_ENCODED}&type=users" \
+  "You are on GitHub user search results for {FULL_NAME} at {COMPANY}.
+   Find the most likely profile match. Click it.
+   On their GitHub profile extract:
+   - Username
+   - Bio
+   - Location
+   - Company listed on profile
+   - Pinned repositories (name, description, language, stars)
+   - Most used programming languages (visible in stats or repos)
+   - Any notable open source contributions or projects
+   STRICT RULES:
+   - Click only the single most relevant result
+   - Do NOT navigate to individual repos
+   - Read only what is visible on their profile page
+   - If no clear match found, return {found: false}
+   Return JSON: {found: bool, username, bio, location, pinned_repos: [{name, description, language, stars}], languages: [], notable_work}" \
+  --sync > /tmp/smi_github.json &
+
+# Agent 3 — Twitter/X
+tinyfish agent run \
+  --url "https://x.com/search?q={FULL_NAME_ENCODED}+{COMPANY_ENCODED}&src=typed_query&f=user" \
+  "You are on Twitter/X user search results for {FULL_NAME} at {COMPANY}.
+   Find the most likely profile match. Click it.
+   On their Twitter profile extract:
+   - Display name and handle
+   - Bio
+   - Pinned tweet (if any)
+   - Topics they tweet about most (infer from visible tweets — read up to 10)
+   - Any strong opinions or recurring themes
+   - Approximate tweet frequency / activity level
+   STRICT RULES:
+   - Click only the most relevant profile
+   - Read only the first 10 visible tweets — do NOT scroll further
+   - Do NOT click any tweet links or replies
+   - If no match found, return {found: false}
+   Return JSON: {found: bool, handle, bio, pinned_tweet, topics: [], opinions: [], activity_level}" \
+  --sync > /tmp/smi_twitter.json &
+
+# Agent 4 — Google News & web mentions
+tinyfish agent run \
+  --url "https://www.google.com/search?q=\"{FULL_NAME_ENCODED}\"+\"{COMPANY_ENCODED}\"&tbm=nws" \
+  "You are on Google News search results for {FULL_NAME} at {COMPANY}.
+   Read the titles and snippets of the first 10 visible news results.
+   Extract:
+   - Any articles authored by or quoting {FULL_NAME}
+   - Key topics they are associated with in the news
+   - Any notable achievements, announcements, or controversies mentioned
+   STRICT RULES:
+   - Do NOT click any article links
+   - Read only titles and snippets visible in the search listing
+   - Maximum 10 results then stop
+   Return JSON: {mentions: [{title, snippet, source, date}], topics: [], authored_articles: []}" \
+  --sync > /tmp/smi_news.json &
+
+# Agent 5 — Company engineering blog
+tinyfish agent run \
+  --url "https://www.google.com/search?q=site:{COMPANY_DOMAIN}+\"{FULL_NAME_ENCODED}\"" \
+  "You are on Google search results filtered to {COMPANY}'s website for content authored by or mentioning {FULL_NAME}.
+   Read the visible results.
+   Extract:
+   - Any blog posts, articles, or pages authored by {FULL_NAME}
+   - Topics they write about at the company
+   - Any technical decisions or opinions expressed
+   STRICT RULES:
+   - Do NOT click any result links
+   - Read only titles and snippets from the search listing
+   - Maximum 8 results then stop
+   - If no results, return {found: false}
+   Return JSON: {found: bool, articles: [{title, snippet, url, topic}]}" \
+  --sync > /tmp/smi_blog.json &
+
+# Agent 6 — Conference talks
+tinyfish agent run \
+  --url "https://www.google.com/search?q=\"{FULL_NAME_ENCODED}\"+\"{COMPANY_ENCODED}\"+(talk+OR+keynote+OR+conference+OR+speaker+OR+presentation)" \
+  "You are on Google search results for conference talks and presentations by {FULL_NAME} at {COMPANY}.
+   Read the visible results.
+   Extract any conference talks, keynotes, podcast appearances, or panel discussions they have participated in:
+   - Talk title
+   - Event name
+   - Year
+   - Topic / summary from the snippet
+   STRICT RULES:
+   - Do NOT click any links
+   - Read only titles and snippets
+   - Maximum 8 results then stop
+   - If no results, return {found: false}
+   Return JSON: {found: bool, talks: [{title, event, year, topic}]}" \
+  --sync > /tmp/smi_talks.json &
+
+# Wait for all agents to complete
+wait
+
+echo "=== LINKEDIN ===" && cat /tmp/smi_linkedin.json
+echo "=== GITHUB ===" && cat /tmp/smi_github.json
+echo "=== TWITTER ===" && cat /tmp/smi_twitter.json
+echo "=== NEWS ===" && cat /tmp/smi_news.json
+echo "=== BLOG ===" && cat /tmp/smi_blog.json
+echo "=== TALKS ===" && cat /tmp/smi_talks.json
+```
+
+**Before running**, replace:
+- `{FULL_NAME}` — e.g. `Sarah Chen`
+- `{FULL_NAME_ENCODED}` — URL-encoded e.g. `Sarah%20Chen`
+- `{COMPANY}` — e.g. `Stripe`
+- `{COMPANY_ENCODED}` — URL-encoded e.g. `Stripe`
+- `{COMPANY_DOMAIN}` — e.g. `stripe.com` (infer from company name for well-known companies; ask the user if unsure)
+
+---
+
+## Step 3 — Synthesize the prep report
+
+Combine all results into a structured report. Only include sections where real data was found — do not pad with guesses.
+
+```
+## Interviewer Research Report — {FULL_NAME}, {COMPANY}
+*Researched: {date}*
+
+---
+
+### 👤 Background
+**Current role:** {title} at {company} ({tenure})
+**Career path:** {brief summary of career trajectory — 2-3 sentences}
+**Education:** {degrees and institutions}
+
+---
+
+### 💻 Technical Profile
+**Languages / Stack:** {programming languages and technologies found}
+**Open source:** {notable repos or contributions, if any}
+**What they build / have built:** {summary from GitHub and blog posts}
+
+*(Skip this section if no technical data found)*
+
+---
+
+### 🧠 What They Care About
+**Recurring themes:** {topics that appear across Twitter, blog posts, talks}
+**Strong opinions:** {any publicly stated views on tech, engineering culture, product, etc.}
+**Published work:** {blog posts, articles, talks — with topics}
+
+---
+
+### 🎤 Conference & Public Presence
+{List of talks or appearances found, with event and year}
+*(Skip if none found)*
+
+---
+
+### 💬 Suggested Conversation Starters
+Based on what you found, specific things you can bring up naturally:
+- {specific thing they worked on or wrote about}
+- {specific opinion or project they're known for}
+- {something from a talk or article that genuinely interests you}
+
+---
+
+### 🎯 How to Tailor Your Interview
+Given their background, here's what to emphasize:
+- {specific advice based on their career path, seniority, or technical focus}
+- {what signals they likely care about based on their public work}
+- {anything to be aware of — e.g. if they wrote critically about X, show you've thought about it}
+
+---
+
+### ⚠️ Gaps in Research
+{List any sources that returned no data or were blocked, so the user knows what's missing}
+```
+
+---
+
+## Edge Cases
+
+- **LinkedIn blocked or requires login** — extract whatever is visible before the gate, note the limitation, rely more heavily on other sources
+- **Very common name** — if search results are ambiguous, stop and ask the user for more context (company URL, LinkedIn profile link, Twitter handle) before proceeding
+- **No public presence found** — be honest: "Limited public information found for {name} at {company}. Here's what was found: [minimal data]. You may want to ask your recruiter for more context or search on LinkedIn directly."
+- **Person is very senior (VP, C-suite)** — news and company blog will be richest; GitHub and Twitter may be sparse
+- **Person is very junior** — GitHub may be the richest source; news and talks likely empty
+- **Role is non-technical** — skip the GitHub agent entirely, weight LinkedIn and blog/news more heavily

--- a/skills/tech-stack-detective/SKILL.md
+++ b/skills/tech-stack-detective/SKILL.md
@@ -1,0 +1,225 @@
+---
+name: tech-stack-detective
+description: Reverse-engineer a company's tech stack from public signals — job listings, StackShare, GitHub, engineering blog, and their live website. Use this skill when a user asks "what tech does Stripe use", "what's Linear's stack", "what does Notion run on", "reverse engineer [company]'s tech stack", "what framework does [company] use", "how is [company] built", "what languages does [company] hire for", or any request to figure out what technology a company uses under the hood.
+---
+
+# Tech Stack Detective
+
+Reverse-engineer any company's tech stack from public signals — job listings, StackShare, GitHub, engineering blog, and their live website — then return a layered map of what they actually run.
+
+## Pre-flight Check (REQUIRED)
+
+Before making any TinyFish call, always run BOTH checks:
+
+**1. CLI installed?**
+```bash
+which tinyfish && tinyfish --version || echo "TINYFISH_CLI_NOT_INSTALLED"
+```
+
+If not installed, stop and tell the user:
+> Install the TinyFish CLI: `npm install -g @tiny-fish/cli`
+
+**2. Authenticated?**
+```bash
+tinyfish auth status
+```
+
+If not authenticated, stop and tell the user:
+> You need a TinyFish API key. Get one at: https://agent.tinyfish.ai/api-keys
+>
+> Then authenticate:
+> ```
+> tinyfish auth login
+> ```
+
+Do NOT proceed until both checks pass.
+
+---
+
+## Step 1 — Gather inputs
+
+You need:
+- **Company name** — e.g. `Stripe`, `Linear`, `Vercel`, `Notion`
+- **Company domain** — e.g. `stripe.com` (infer from company name for well-known companies, ask if unsure)
+
+Optional:
+- **Area of interest** — e.g. "just the frontend", "their data pipeline", "what they use for auth" (if specified, focus the output on that layer)
+
+---
+
+## Step 2 — Parallel research
+
+Fire all 5 agents simultaneously.
+
+```bash
+# Agent 1 — StackShare profile
+tinyfish agent run \
+  --url "https://stackshare.io/{COMPANY_SLUG}" \
+  "You are on the StackShare profile for {COMPANY}.
+   Extract their full tech stack as listed:
+   - All tools and services listed under each category
+   - Category names (e.g. Languages, Frameworks, Data Stores, DevOps, etc.)
+   - Any tools listed as 'used by' this company
+   STRICT RULES:
+   - Do NOT click any tool links
+   - Do NOT navigate away
+   - Read only what is visible on this page
+   - If the page returns 404 or no company found, return {found: false}
+   Return JSON: {found: bool, stack: [{category, tools: []}]}" \
+  --sync > /tmp/tsd_stackshare.json &
+
+# Agent 2 — Job listings (tech signals from requirements)
+tinyfish agent run \
+  --url "https://www.linkedin.com/jobs/search/?keywords={COMPANY_ENCODED}+engineer" \
+  "You are on LinkedIn job listings for {COMPANY}.
+   Read the job titles and visible snippets for engineering roles.
+   Extract all technologies, languages, frameworks, and tools mentioned in:
+   - Job titles
+   - Visible job description snippets
+   Focus on: programming languages, frameworks, databases, cloud providers, tooling.
+   STRICT RULES:
+   - Do NOT click any job listing
+   - Read only titles and visible preview text
+   - Maximum 15 listings then stop
+   - Deduplicate — list each technology once
+   Return JSON: {technologies: [{name, category, mention_count}]}" \
+  --sync > /tmp/tsd_linkedin.json &
+
+# Agent 3 — GitHub organization
+tinyfish agent run \
+  --url "https://github.com/{COMPANY_SLUG}" \
+  "You are on the GitHub organization page for {COMPANY}.
+   Extract signals about their tech stack from public repositories:
+   - Top 6 pinned or most-starred repositories
+   - Primary programming languages used across repos (visible in language bars)
+   - Any infrastructure or tooling repos (e.g. terraform, kubernetes configs, SDKs)
+   - Any open source projects that reveal their internal stack
+   STRICT RULES:
+   - Do NOT click into any repository
+   - Read only what is visible on the org page
+   - If no org found, return {found: false}
+   Return JSON: {found: bool, top_repos: [{name, description, language, stars}], languages: [], infra_signals: []}" \
+  --sync > /tmp/tsd_github.json &
+
+# Agent 4 — Engineering blog
+tinyfish agent run \
+  --url "https://www.google.com/search?q=site:{COMPANY_DOMAIN}+engineering+OR+blog+OR+tech" \
+  "You are on Google search results for the engineering blog of {COMPANY} at {COMPANY_DOMAIN}.
+   Find the engineering or tech blog URL, then read the visible post titles and snippets.
+   Extract:
+   - Technologies, tools, or architectural decisions mentioned in post titles and snippets
+   - Any posts about infrastructure, scaling, or architecture decisions
+   - Any open source tools they built or adopted
+   STRICT RULES:
+   - Do NOT click any links
+   - Read only titles and snippets visible in search results
+   - Maximum 10 results then stop
+   Return JSON: {blog_url, tech_signals: [{technology, context}], architecture_posts: [{title, snippet}]}" \
+  --sync > /tmp/tsd_blog.json &
+
+# Agent 5 — Live website analysis
+tinyfish agent run \
+  --url "https://{COMPANY_DOMAIN}" \
+  "You are on {COMPANY}'s homepage at {COMPANY_DOMAIN}.
+   Analyze the page for frontend technology signals:
+   - JavaScript framework clues (React, Vue, Angular, Svelte, etc.) — look for script tags, __NEXT_DATA__, __nuxt, ng-, data-reactroot, etc.
+   - CSS framework signals (Tailwind classes, Bootstrap, etc.)
+   - Analytics tools (Google Analytics, Segment, Mixpanel, etc.)
+   - CDN or hosting signals (Vercel, Cloudflare, Fastly, etc.)
+   - Any visible 'built with' or 'powered by' badges
+   - Meta tags that reveal framework or CMS
+   STRICT RULES:
+   - Do NOT navigate away from the homepage
+   - Read source signals from the visible page
+   - Return only what you can confidently infer — do not guess
+   Return JSON: {frontend_framework, css_framework, analytics: [], cdn_hosting, other_signals: []}" \
+  --sync > /tmp/tsd_website.json &
+
+wait
+
+echo "=== STACKSHARE ===" && cat /tmp/tsd_stackshare.json
+echo "=== JOBS ===" && cat /tmp/tsd_linkedin.json
+echo "=== GITHUB ===" && cat /tmp/tsd_github.json
+echo "=== BLOG ===" && cat /tmp/tsd_blog.json
+echo "=== WEBSITE ===" && cat /tmp/tsd_website.json
+```
+
+**Before running**, replace:
+- `{COMPANY}` — e.g. `Stripe`
+- `{COMPANY_SLUG}` — lowercase, hyphenated e.g. `stripe`
+- `{COMPANY_ENCODED}` — URL-encoded e.g. `Stripe`
+- `{COMPANY_DOMAIN}` — e.g. `stripe.com`
+
+---
+
+## Step 3 — Synthesize the stack map
+
+Combine signals from all sources. Assign a confidence level to each technology based on how many sources confirmed it:
+
+- **High confidence** — mentioned in 3+ sources or explicitly listed on StackShare
+- **Medium confidence** — mentioned in 2 sources or inferred from job listings
+- **Low confidence** — mentioned in only 1 source or inferred from indirect signals
+
+```
+## Tech Stack — {COMPANY}
+
+*Reverse-engineered from StackShare, job listings, GitHub, engineering blog, and live site analysis*
+*Data fetched: {date}*
+
+---
+
+### 🖥️ Frontend
+| Technology | Confidence | Source |
+|---|---|---|
+| {tech} | 🟢 High / 🟡 Medium / 🔴 Low | {sources} |
+
+### ⚙️ Backend
+| Technology | Confidence | Source |
+|---|---|---|
+
+### 🗄️ Data & Storage
+| Technology | Confidence | Source |
+|---|---|---|
+
+### ☁️ Infrastructure & DevOps
+| Technology | Confidence | Source |
+|---|---|---|
+
+### 📊 Analytics & Monitoring
+| Technology | Confidence | Source |
+|---|---|---|
+
+### 🔧 Developer Tooling
+| Technology | Confidence | Source |
+|---|---|---|
+
+---
+
+### 🧠 Key Architectural Signals
+{2-4 bullet points on notable architectural choices inferred from the research}
+- e.g. "Strong Go + Rust signals in job listings suggest performance-critical backend services"
+- e.g. "Multiple Kubernetes and Terraform repos on GitHub indicate heavy infrastructure-as-code culture"
+
+---
+
+### 🔍 Sources
+- StackShare: {found / not found}
+- Job listings: {N} engineering roles analyzed
+- GitHub: {N} public repos
+- Engineering blog: {blog_url or not found}
+- Live site analysis: {COMPANY_DOMAIN}
+
+### ⚠️ Low Confidence Items
+{List technologies with only 1 source signal and what that signal was}
+```
+
+---
+
+## Edge Cases
+
+- **StackShare profile doesn't exist** — skip it, rely on other 4 sources, note the gap
+- **Company GitHub org not found** — try common variations (`{company}hq`, `{company}-inc`, `{company}io`) before giving up
+- **Private company with minimal public presence** — job listings and website analysis will be the richest sources; be upfront about confidence levels
+- **Very large company** (Google, Meta, Amazon) — stack is extremely diverse; ask if the user wants a specific team or product area, otherwise summarize known public stacks
+- **Startup with almost no public signals** — be honest: "Limited public signals found. Based on job listings alone: [findings]"
+- **Company uses different names** on GitHub vs LinkedIn — use the domain as the anchor and note the discrepancy


### PR DESCRIPTION
## Summary

Adds 7 new agent skills to the cookbook, covering developer workflows and everyday use cases:

| Skill | What it does |
|-------|-------------|
| `stalk-my-interviewer` | Deploys parallel agents across LinkedIn, GitHub, Twitter/X, news, and conference platforms to build a pre-interview research report |
| `leetcode-coach` | Finds coding problems matched to your weak areas from LeetCode, HackerRank, and Codeforces — sets up local files or links to the problem online |
| `npm-package-comparator` | Compares packages side by side using live data from npm, GitHub, Bundlephobia, and Snyk |
| `tech-stack-detective` | Reverse-engineers a company's tech stack from job listings, StackShare, GitHub org, engineering blog, and live site analysis |
| `salary-market-scanner` | Scrapes Levels.fyi, Glassdoor, LinkedIn, and Indeed for real-time compensation data for any role and location |
| `freelance-gig-finder` | Searches Upwork, Contra, We Work Remotely, Freelancer, and LinkedIn simultaneously for fresh freelance gigs |
| `hackathon-finder` | Matches upcoming hackathons to your tech profile and location via Devpost, MLH, Luma, and Eventbrite |

## Format
All skills follow the correct structure:
- Flat `skills/skill-name/SKILL.md` — no nesting, no binary files
- Frontmatter: `name` + `description` with strong trigger phrases only
- Pre-flight check (CLI install + auth) in every skill
- Parallel TinyFish calls with `&` + `wait` throughout