### PR TITLE
Strengthen kb-builder synthesis defaults

### DIFF
--- a/skills/kb-builder/README.md
+++ b/skills/kb-builder/README.md
@@ -7,6 +7,7 @@ Ask your coding agent things like:
 - *"Build me a knowledge base on Kolmogorov-Arnold Networks"*
 - *"Build me a knowledge base on landing page design patterns, start from these URLs..."*
 - *"Update my KAN knowledge base with these 3 new URLs"*
+- *"Build me a knowledge base on browser agents --trace"*
 
 The agent uses TinyFish's web agent to visit public sources, extract the highest-signal information, and write a clean markdown vault with `[[wikilinks]]`.
 
@@ -24,6 +25,7 @@ The goal is not just to summarize sources. The skill is meant to synthesize the 
 - **Topic only** — the agent starts from search and hub pages
 - **Topic + starter URLs** — the agent uses your URLs first, then expands from there
 - **Update an existing KB** — the agent adds new sources into an existing vault instead of rebuilding blindly
+- **Optional trace mode** — `--trace` saves raw TinyFish outputs in `_trace/` for debugging and deeper inspection
 
 ## Output
 
@@ -43,6 +45,7 @@ Generated only when relevant:
 - `people.md`
 - other topic-specific markdown files
 - `updates.md` when the KB is refreshed
+- `_trace/` only when `--trace` is used
 
 ## Requirements
 
@@ -60,6 +63,7 @@ Generated only when relevant:
 - Honest audit trail with `FOUND`, `INFERRED`, `CONFLICTING`, and `MISSING`
 - Update mode for refreshing an existing KB with new sources
 - Stronger synthesis defaults so the KB feels like understanding, not just summaries
+- Optional trace mode when you want raw TinyFish responses for inspection
 
 ## Built for
 

--- a/skills/kb-builder/README.md
+++ b/skills/kb-builder/README.md
@@ -10,6 +10,15 @@ Ask your coding agent things like:
 
 The agent uses TinyFish's web agent to visit public sources, extract the highest-signal information, and write a clean markdown vault with `[[wikilinks]]`.
 
+The goal is not just to summarize sources. The skill is meant to synthesize the field:
+
+- what the core mental model is
+- what actually matters
+- what the main approaches are
+- what is foundational vs derivative
+- what is still unresolved
+- what to read first if you want real understanding
+
 ## Input modes
 
 - **Topic only** — the agent starts from search and hub pages
@@ -50,6 +59,7 @@ Generated only when relevant:
 - Honest logging of every visited URL in `sources.md`
 - Honest audit trail with `FOUND`, `INFERRED`, `CONFLICTING`, and `MISSING`
 - Update mode for refreshing an existing KB with new sources
+- Stronger synthesis defaults so the KB feels like understanding, not just summaries
 
 ## Built for
 

--- a/skills/kb-builder/SKILL.md
+++ b/skills/kb-builder/SKILL.md
@@ -8,7 +8,8 @@ description: >
   Supports both first-build and update workflows. Always generates index.md, sources.md, audit.md,
   and manifest.json. Creates additional files only when the evidence supports them. The output must
   synthesize the topic into a usable mental model, not just summarize pages. Uses explicit
-  tinyfish agent run commands and public web sources only.
+  tinyfish agent run commands and public web sources only. Optional `--trace` mode saves raw
+  TinyFish outputs under `_trace/` for debugging.
 ---
 
 # KB Builder
@@ -74,6 +75,8 @@ You support two modes:
    - Example: `Build me a knowledge base on web agent frameworks and start from these URLs: ...`
 3. **Update an existing KB**
    - Example: `Update my knowledge base on Kolmogorov-Arnold Networks with these new URLs: ...`
+4. **Trace mode**
+   - Example: `Build me a knowledge base on browser agents --trace`
 
 If the topic is missing, ask for it before proceeding.
 
@@ -83,6 +86,11 @@ If starter URLs are present:
 - keep only public URLs
 
 If the user explicitly says `update`, `refresh`, `add these sources`, or clearly wants to add to an existing KB, switch into update mode.
+
+If the user includes `--trace`, `trace`, `debug`, or explicitly asks for raw outputs:
+- enable trace mode
+- save raw TinyFish outputs under `_trace/`
+- keep `_trace/` out of the main page navigation unless the user asks for it
 
 ## Output directory
 
@@ -96,6 +104,12 @@ Examples:
 - `kb-web-agent-frameworks/`
 - `kb-kolmogorov-arnold-networks/`
 - `kb-landing-page-design-patterns/`
+
+When trace mode is enabled, also create:
+
+```text
+kb-{topic-slug}/_trace/
+```
 
 ## Always-generated files
 
@@ -184,6 +198,7 @@ This file is always required. It stores:
 - page list
 - run history
 - simple run bookkeeping like URLs visited and pages generated
+- whether trace mode was enabled
 
 ## Dynamic files
 
@@ -218,6 +233,10 @@ Rules:
 
 All generated markdown files should use `[[wikilinks]]` when linking to other local pages.
 
+Trace mode exception:
+- files under `_trace/` are debugging artifacts, not user-facing KB pages
+- do not clutter `index.md` with `_trace/` links unless the user explicitly asks
+
 ## Operating model
 
 Use a **two-pass workflow**:
@@ -240,6 +259,10 @@ Determine whether this run is:
 - `build` — creating a KB from scratch
 - `update` — adding or refreshing sources in an existing KB
 
+Also determine:
+
+- `TRACE` = `true` or `false`
+
 Use `update` mode when:
 
 - the user explicitly says update or refresh
@@ -261,6 +284,7 @@ Write down:
 - `TOPIC_SLUG`
 - `STARTER_URLS` if provided
 - `MODE` = `build` or `update`
+- `TRACE` = `true` or `false`
 
 Keep the topic human-readable in the markdown output.
 
@@ -342,6 +366,12 @@ After launching all discovery runs:
 wait
 ```
 
+If `TRACE=true`, copy or save the raw discovery outputs into `_trace/` with readable names such as:
+
+- `_trace/discovery-github.json`
+- `_trace/discovery-arxiv.json`
+- `_trace/discovery-ddg.json`
+
 Then read all discovery outputs, merge them, deduplicate by URL, and choose the best 6-12 URLs for the reading pass.
 
 Selection priority:
@@ -402,6 +432,14 @@ After launching all reading runs:
 ```bash
 wait
 ```
+
+If `TRACE=true`, save the raw reading outputs into `_trace/` as well, for example:
+
+- `_trace/read-paper.json`
+- `_trace/read-repo-main.json`
+- `_trace/read-docs.json`
+
+Do not summarize `_trace/` into the main KB pages. It exists for inspection, debugging, and trust when needed.
 
 ## Step 5 — Log all sources immediately
 
@@ -587,6 +625,7 @@ At minimum, store:
 - `topic`
 - `topic_slug`
 - `mode`
+- `trace`
 - `created_at`
 - `last_updated_at`
 - `pages`
@@ -612,6 +651,7 @@ Always follow these rules:
 - every major page should answer "why does this matter?" not only "what is this?"
 - if multiple sources restate the same point, compress them into one synthesized claim instead of duplicating summaries
 - include a reading path for the strongest or most foundational sources when the topic is broad
+- raw TinyFish outputs should only be stored when trace mode is requested
 
 ## Parallelism rule
 
@@ -651,6 +691,7 @@ At the end, report:
 - files created
 - number of URLs visited
 - mode: build or update
+- trace: on or off
 - any important gaps or blocked sources
 
 Use a concise summary like:
@@ -659,6 +700,7 @@ Use a concise summary like:
 KB Builder complete for {TOPIC}
 Output: kb-{topic-slug}/
 Mode: {MODE}
+Trace: {TRACE}
 Files: index.md, sources.md, ...
 URLs visited: 11
 Open gaps: benchmarks unclear, no public dataset page found

--- a/skills/kb-builder/SKILL.md
+++ b/skills/kb-builder/SKILL.md
@@ -6,7 +6,8 @@ description: >
   asks for a structured research vault, or wants a topic compiled from live public sources into
   interlinked markdown files. Supports two input modes: topic only, or topic plus starter URLs.
   Supports both first-build and update workflows. Always generates index.md, sources.md, audit.md,
-  and manifest.json. Creates additional files only when the evidence supports them. Uses explicit
+  and manifest.json. Creates additional files only when the evidence supports them. The output must
+  synthesize the topic into a usable mental model, not just summarize pages. Uses explicit
   tinyfish agent run commands and public web sources only.
 ---
 
@@ -17,6 +18,21 @@ Build a topic-specific markdown knowledge base by using TinyFish to browse publi
 This skill is for **builder knowledge bases**, not personal journals and not direct code generation.
 
 The output is a folder you can drop into Obsidian immediately, and update later without starting over.
+
+## Core principle
+
+Do not produce a pile of source summaries.
+
+The KB should help the reader understand:
+
+- the core mental model
+- the main approaches or schools of thought
+- what is foundational vs derivative
+- what actually matters
+- what is unresolved
+- what to read first if they want genuine understanding
+
+If the output only says what each source said, the skill has failed.
 
 ## Pre-flight check
 
@@ -91,6 +107,9 @@ This file is always required. It should contain:
 - a list of generated pages using `[[wikilinks]]`
 - 3-7 key takeaways
 - open questions or evidence gaps
+- a **mental model** section
+- a **what matters** section
+- a **reading order** section for the strongest sources or pages
 
 ### `sources.md`
 
@@ -182,6 +201,10 @@ Common examples:
 - `people.md`
 - `glossary.md`
 - `timeline.md`
+- `landscape.md`
+- `reading-order.md`
+- `disagreements.md`
+- `what-matters.md`
 
 Rules:
 - if a category has meaningful evidence, create its file
@@ -189,6 +212,9 @@ Rules:
 - do not create empty placeholder files
 - if a category only has 1-2 minor findings, fold it into `index.md` instead
 - create `updates.md` when the KB is refreshed in update mode
+- if the topic is broad enough to have multiple camps, phases, or implementation styles, create `landscape.md`
+- if the sources disagree in meaningful ways, create `disagreements.md`
+- if the reader would benefit from a guided path, create `reading-order.md`
 
 All generated markdown files should use `[[wikilinks]]` when linking to other local pages.
 
@@ -270,6 +296,15 @@ Only include discovery URLs that are likely to produce useful public results.
 
 Aim for 4-8 discovery URLs in the first pass, not 20.
 
+When selecting discovery and reading targets, prefer sources that improve understanding, not just coverage:
+
+- canonical or foundational sources
+- implementation anchors
+- benchmark or comparison sources
+- one or two strong explainers that clarify the field
+
+Do not spend most of your budget on redundant summaries of the same idea.
+
 ## Step 3 — Run the discovery pass
 
 For each discovery URL, run TinyFish with a concrete extraction goal.
@@ -335,6 +370,10 @@ tinyfish agent run --sync --url "{TARGET_URL}" \
    - sourceType
    - shortSummary
    - keyFindings: up to 7 bullets
+   - whyItMatters
+   - foundationality: foundational|important|derivative|unclear
+   - approachOrSchool: the main approach, camp, or framing this source represents
+   - whatThisChanges: one line on how this source changes the reader's understanding
    - importantEntities: people, projects, libraries, datasets, papers, companies
    - importantLinks: up to 5 URLs mentioned or linked from the page
    - suggestedPages: page names this should contribute to, e.g. [\"repos\", \"papers\", \"docs\", \"articles\", \"benchmarks\"]
@@ -350,6 +389,9 @@ tinyfish agent run --sync --url "{TARGET_URL}" \
    - extract concepts, APIs, workflows, and caveats
    If this is a dataset or model page:
    - extract task, modality, schema if visible, and usage constraints
+   Also extract:
+   - what this source says that is actually important
+   - what this source does NOT resolve
    Return JSON only.
    Do not invent facts. If something is missing, say it is missing." \
   > /tmp/kb_read_{SAFE_NAME}.json &
@@ -401,7 +443,37 @@ For especially important claims in topic pages, you may add inline markers like:
 
 Use them sparingly. Do not turn every line into metadata noise.
 
-## Step 7 — Decide the page set
+## Step 7 — Build the synthesis layer
+
+Before deciding the final page set, synthesize the field as a field.
+
+You must identify:
+
+- the core mental model
+- the main approaches, camps, or architectural patterns
+- which sources are foundational
+- which sources are implementation-oriented
+- which sources are mostly derivative or explanatory
+- the biggest unresolved questions or disagreements
+- the best reading order for someone who wants real understanding
+
+If the topic is broad and source-rich, this synthesis should appear in:
+
+- `index.md`
+- and, when justified, one or more of:
+  - `landscape.md`
+  - `reading-order.md`
+  - `disagreements.md`
+  - `what-matters.md`
+
+Anti-summary rule:
+
+- do not let every page become "source A says X, source B says Y"
+- collapse repetition
+- explain what the repetition means
+- separate first-order ideas from derivative restatements
+
+## Step 8 — Decide the page set
 
 Create the optional pages based on the actual evidence you found.
 
@@ -416,7 +488,7 @@ If the topic does **not** have a category, skip that file.
 
 Do not create a research-shaped output for topics that are not research-shaped.
 
-## Step 8 — Write the knowledge base
+## Step 9 — Write the knowledge base
 
 Write clean markdown. Keep it skimmable and builder-friendly.
 
@@ -430,6 +502,9 @@ Use this pattern:
 ## Overview
 {2-4 paragraph overview}
 
+## Mental Model
+{Explain the topic so a smart builder can actually understand the structure of the space.}
+
 ## Pages
 - [[docs]]
 - [[repos]]
@@ -441,6 +516,11 @@ Use this pattern:
 
 ## Gaps
 - ...
+
+## Reading Order
+- {what to read first}
+- {what to read second}
+- {what to skip until later}
 
 ## Source Log
 - [[sources]]
@@ -463,6 +543,8 @@ Each optional page should:
 - organize findings under clear headings
 - include outbound `[[wikilinks]]` to sibling pages where relevant
 - include source links inline as standard markdown links
+- include a short section on why the page matters in the bigger picture
+- avoid repeating material that belongs more naturally in another page
 
 Example:
 
@@ -512,7 +594,7 @@ At minimum, store:
 
 Append a new run entry on each build or update.
 
-## Step 9 — Quality rules
+## Step 10 — Quality rules
 
 Always follow these rules:
 
@@ -526,6 +608,10 @@ Always follow these rules:
 - if a source is weak, say so explicitly
 - if you cannot access a page or it is thin, record that in `sources.md`
 - if the KB is being updated, do not destroy prior valid work just because new sources were added
+- the KB should teach the reader how to think about the topic, not just what links were visited
+- every major page should answer "why does this matter?" not only "what is this?"
+- if multiple sources restate the same point, compress them into one synthesized claim instead of duplicating summaries
+- include a reading path for the strongest or most foundational sources when the topic is broad
 
 ## Parallelism rule
 


### PR DESCRIPTION
## Summary
- make kb-builder synthesize the field instead of mostly summarizing sources
- add stronger default sections for mental model, what matters, and reading order
- add dynamic page guidance for landscape, disagreements, reading-order, and what-matters pages when topic warrants it
- add anti-summary rules so repeated source points get compressed into higher-level understanding

## Why
The current skill structure is good, but the output can still feel too summary-heavy. This follow-up pushes the skill toward understanding-first output by default, so users do not need to over-specify that in every prompt.
