### PR TITLE
Competitor scout migration sdk

### DIFF
--- a/competitor-scout-cli/cli/scout.mjs
+++ b/competitor-scout-cli/cli/scout.mjs
@@ -17,6 +17,7 @@
 
 import fs from "fs";
 import path from "path";
+import { TinyFish } from "@tiny-fish/sdk";
 
 const CONFIG_FILE = path.resolve(process.cwd(), ".scout.json");
 const RUNS_FILE = path.resolve(process.cwd(), ".scout-runs.json");
@@ -165,50 +166,47 @@ function requireEnv(name) {
 
 // ─── Tinyfish Client ────────────────────────────────────────────────────────
 
+let tinyfishClient = null;
+function getTinyfishClient() {
+  // Validate env early for friendlier errors; SDK reads env itself.
+  requireEnv("TINYFISH_API_KEY");
+  if (!tinyfishClient) tinyfishClient = new TinyFish();
+  return tinyfishClient;
+}
+
 async function tinyfishSubmit(url, goal) {
-  const apiKey = requireEnv("TINYFISH_API_KEY");
-  const res = await fetch(`${TINYFISH_BASE}/automation/run-async`, {
-    method: "POST",
-    headers: { "X-API-Key": apiKey, "Content-Type": "application/json" },
-    body: JSON.stringify({ url, goal }),
-  });
-  if (!res.ok) throw new Error(`Tinyfish submit failed: ${await res.text()}`);
-  const data = await res.json();
+  const data = await getTinyfishClient().agent.queue({ url, goal });
+  if (data.error) {
+    throw new Error(`Failed to queue Tinyfish run: ${data.error.message || "Unknown error"}`);
+  }
+  if (!data.run_id) {
+    throw new Error("Tinyfish queue did not return a run_id");
+  }
   return data.run_id;
 }
 
 async function tinyfishStatus(runId) {
-  const apiKey = requireEnv("TINYFISH_API_KEY");
   const maxAttempts = 3;
   let attempt = 0;
   let lastError = null;
 
   while (attempt < maxAttempts) {
     attempt += 1;
-    const res = await fetch(`${TINYFISH_BASE}/runs/${runId}`, {
-      headers: { "X-API-Key": apiKey },
-    });
-    if (res.ok) return await res.json();
-    const text = await res.text();
-    lastError = new Error(`Tinyfish status failed: ${text}`);
-    if (res.status >= 500 && attempt < maxAttempts) {
+    try {
+      return await getTinyfishClient().runs.get(runId);
+    } catch (e) {
+      lastError = e instanceof Error ? e : new Error(String(e));
       await new Promise((r) => setTimeout(r, 1000 * attempt));
-      continue;
+      if (attempt < maxAttempts) continue;
+      throw lastError;
     }
-    throw lastError;
   }
 
   throw lastError || new Error("Tinyfish status failed");
 }
 
 async function tinyfishCancel(runId) {
-  const apiKey = requireEnv("TINYFISH_API_KEY");
-  const res = await fetch(`${TINYFISH_BASE}/runs/${runId}/cancel`, {
-    method: "POST",
-    headers: { "X-API-Key": apiKey },
-  });
-  if (!res.ok) throw new Error(`Tinyfish cancel failed: ${await res.text()}`);
-  return await res.json();
+  return await getTinyfishClient().runs.cancel(runId);
 }
 
 async function tinyfishWait(runId, label, onStatus) {

--- a/competitor-scout-cli/lib/tinyfish.ts
+++ b/competitor-scout-cli/lib/tinyfish.ts
@@ -1,6 +1,7 @@
 import { ensureLocalEnvLoaded } from "./env";
+import { TinyFish } from "@tiny-fish/sdk";
 
-const TINYFISH_BASE_URL = "https://agent.tinyfish.ai/v1";
+let client: TinyFish | null = null;
 
 function getApiKey(): string {
   ensureLocalEnvLoaded();
@@ -9,25 +10,30 @@ function getApiKey(): string {
   return key;
 }
 
+function getClient(): TinyFish {
+  // Validate env early for nicer errors; SDK reads env itself.
+  getApiKey();
+  if (!client) {
+    client = new TinyFish();
+  }
+  return client;
+}
+
 export async function submitRun(
   url: string,
   goal: string
 ): Promise<string> {
-  const response = await fetch(`${TINYFISH_BASE_URL}/automation/run-async`, {
-    method: "POST",
-    headers: {
-      "X-API-Key": getApiKey(),
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify({ url, goal }),
-  });
-
-  if (!response.ok) {
-    const text = await response.text();
-    throw new Error(`Tinyfish submit failed (${response.status}): ${text}`);
+  const result = await getClient().agent.queue({ url, goal });
+  if (result.error) {
+    const message =
+      typeof result.error === "object" && "message" in result.error
+        ? String((result.error as { message?: unknown }).message ?? "")
+        : String(result.error);
+    throw new Error(`Failed to queue Tinyfish run: ${message || "Unknown error"}`);
   }
-
-  const result = await response.json();
+  if (!result.run_id) {
+    throw new Error("Tinyfish queue did not return a run_id");
+  }
   return result.run_id;
 }
 
@@ -43,28 +49,30 @@ export async function getRunStatus(runId: string): Promise<{
 
   while (attempt < maxAttempts) {
     attempt += 1;
-    const response = await fetch(`${TINYFISH_BASE_URL}/runs/${runId}`, {
-      headers: {
-        "X-API-Key": getApiKey(),
-      },
-    });
+    try {
+      const run = await getClient().runs.get(runId);
+      const errorMessage =
+        run.error && typeof run.error === "object" && "message" in run.error
+          ? String((run.error as { message?: unknown }).message ?? "")
+          : run.error
+            ? JSON.stringify(run.error)
+            : undefined;
 
-    if (response.ok) {
-      return await response.json();
+      return {
+        run_id: run.run_id,
+        status: run.status,
+        result: run.result,
+        error: errorMessage,
+      };
+    } catch (e) {
+      const error = e instanceof Error ? e : new Error(String(e));
+      lastError = error;
+      if (attempt < maxAttempts) {
+        await new Promise((resolve) => setTimeout(resolve, 1000 * attempt));
+        continue;
+      }
+      throw error;
     }
-
-    const text = await response.text();
-    const error = new Error(
-      `Tinyfish status check failed (${response.status}): ${text}`
-    );
-    lastError = error;
-
-    if (response.status >= 500 && attempt < maxAttempts) {
-      await new Promise((resolve) => setTimeout(resolve, 1000 * attempt));
-      continue;
-    }
-
-    throw error;
   }
 
   throw lastError ?? new Error("Tinyfish status check failed");

--- a/competitor-scout-cli/package-lock.json
+++ b/competitor-scout-cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "my-v0-project",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "my-v0-project",
-      "version": "0.1.0",
+      "version": "1.0.0",
       "dependencies": {
         "@hookform/resolvers": "^3.10.0",
         "@radix-ui/react-accordion": "1.2.2",
@@ -36,6 +36,7 @@
         "@radix-ui/react-toggle": "1.1.1",
         "@radix-ui/react-toggle-group": "1.1.1",
         "@radix-ui/react-tooltip": "1.1.6",
+        "@tiny-fish/sdk": "^0.0.7",
         "@vercel/analytics": "1.3.1",
         "autoprefixer": "^10.4.20",
         "class-variance-authority": "^0.7.1",
@@ -2401,6 +2402,27 @@
         "tailwindcss": "4.1.18"
       }
     },
+    "node_modules/@tiny-fish/sdk": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@tiny-fish/sdk/-/sdk-0.0.7.tgz",
+      "integrity": "sha512-VzBTKwYfJZEkNpj56kyBGnT6m8DNaXdDSaDImTC6t/9IyIcXguqrB83pyioRs23vIhQs+soNs8vgYASALDmtsA==",
+      "dependencies": {
+        "p-retry": "^7.1.1",
+        "zod": "^4.3.6"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@tiny-fish/sdk/node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
     "node_modules/@types/d3-array": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
@@ -2963,6 +2985,18 @@
         "node": ">=12"
       }
     },
+    "node_modules/is-network-error": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/is-network-error/-/is-network-error-1.3.1.tgz",
+      "integrity": "sha512-6QCxa49rQbmUWLfk0nuGqzql9U8uaV2H6279bRErPBHe/109hCzsLUBUHfbEtvLIHBd6hyXbgedBSHevm43Edw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/jiti": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
@@ -3398,6 +3432,21 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/p-retry": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-7.1.1.tgz",
+      "integrity": "sha512-J5ApzjyRkkf601HpEeykoiCvzHQjWxPAHhyjFcEUP2SWq0+35NKh8TLhpLw+Dkq5TZBFvUM6UigdE9hIVYTl5w==",
+      "license": "MIT",
+      "dependencies": {
+        "is-network-error": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/picocolors": {

--- a/competitor-scout-cli/package.json
+++ b/competitor-scout-cli/package.json
@@ -37,6 +37,7 @@
     "@radix-ui/react-toggle": "1.1.1",
     "@radix-ui/react-toggle-group": "1.1.1",
     "@radix-ui/react-tooltip": "1.1.6",
+    "@tiny-fish/sdk": "^0.0.7",
     "@vercel/analytics": "1.3.1",
     "autoprefixer": "^10.4.20",
     "class-variance-authority": "^0.7.1",


### PR DESCRIPTION
Migrated the competitor scout CLI to use the new tinyfish SDK instead of making HTTP requests