### PR TITLE
Add Claude Code marketplace and TinyFish plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,32 @@
+{
+  "name": "tinyfish-marketplace",
+  "owner": {
+    "name": "TinyFish",
+    "email": "support@tinyfish.io"
+  },
+  "metadata": {
+    "description": "Official TinyFish plugins for Claude Code",
+    "version": "1.0.0",
+    "pluginRoot": "./plugins"
+  },
+  "plugins": [
+    {
+      "name": "tinyfish",
+      "source": "./tinyfish",
+      "description": "Automate complex tasks on the web using natural language. TinyFish's Web Agent navigates sites, fills forms, extracts data, and completes multi-step browser workflows.",
+      "version": "1.0.0",
+      "author": {
+        "name": "TinyFish",
+        "url": "https://tinyfish.ai"
+      },
+      "category": "automation",
+      "tags": [
+        "web-automation",
+        "web-agent",
+        "browser-automation",
+        "web-scraping",
+        "data-extraction"
+      ]
+    }
+  ]
+}

--- a/plugins/tinyfish/.claude-plugin/plugin.json
+++ b/plugins/tinyfish/.claude-plugin/plugin.json
@@ -1,0 +1,22 @@
+{
+  "name": "tinyfish",
+  "version": "1.0.0",
+  "description": "Automate complex tasks on the web using natural language. TinyFish's Web Agent navigates sites, fills forms, extracts data, and completes multi-step browser workflows.",
+  "author": {
+    "name": "TinyFish",
+    "email": "support@tinyfish.io",
+    "url": "https://tinyfish.ai"
+  },
+  "homepage": "https://docs.tinyfish.ai",
+  "repository": "https://github.com/tinyfish-io/tinyfish-cookbook",
+  "license": "MIT",
+  "keywords": [
+    "web-automation",
+    "web-agent",
+    "browser-automation",
+    "web-scraping",
+    "data-extraction"
+  ],
+  "skills": "./skills/",
+  "mcpServers": "./.mcp.json"
+}

--- a/plugins/tinyfish/.mcp.json
+++ b/plugins/tinyfish/.mcp.json
@@ -1,0 +1,7 @@
+{
+  "mcpServers": {
+    "tinyfish": {
+      "url": "https://agent.tinyfish.ai/mcp"
+    }
+  }
+}

--- a/plugins/tinyfish/CHANGELOG.md
+++ b/plugins/tinyfish/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+## 1.0.0 (2026-04-12)
+
+### Added
+- Initial release of the TinyFish plugin for Claude Code
+- MCP server integration with TinyFish Web Agent API (OAuth 2.1 authentication)
+- Skill: `/tinyfish:web-agent` — automate browser tasks using natural language
+- Skill: `/tinyfish:tunneling` — expose local ports to the internet via tinyfi.sh
+- MCP tools: `run_web_automation`, `run_web_automation_async`, `get_run`, `list_runs`, `cancel_run`, `batch_create`, `batch_status`, `batch_cancel`

--- a/plugins/tinyfish/skills/tunneling/SKILL.md
+++ b/plugins/tinyfish/skills/tunneling/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: tunneling
+description: Create free SSH tunnels to expose local ports to the internet using tinyfi.sh. Use when you need to share a locally running app, test webhooks, demo a prototype, or get a public HTTPS URL for any local service — no signup or authentication required.
+---
+
+# TinyFish Tunneling Service (tinyfi.sh)
+
+Creates instant public HTTPS URLs for locally running apps via SSH tunneling. Free, no account, no installation beyond SSH.
+
+## Pre-flight Check (REQUIRED)
+
+Verify SSH is available (it almost always is):
+
+```bash
+which ssh && echo "SSH available" || echo "SSH not found — install OpenSSH first"
+```
+
+## Quick Start
+
+Expose a local port to the internet:
+
+```bash
+ssh -o StrictHostKeyChecking=accept-new -R 80:localhost:<PORT> tinyfi.sh
+```
+
+Replace `<PORT>` with the port your app is running on. The command will print a public `https://<random>.tinyfi.sh` URL.
+
+## Custom Subdomain
+
+Request a specific subdomain instead of a random one:
+
+```bash
+ssh -o StrictHostKeyChecking=accept-new -R myname:80:localhost:<PORT> tinyfi.sh
+```
+
+This gives you `https://myname.tinyfi.sh`.
+
+## Keep-Alive (Stable Connections)
+
+For long-running tunnels, add a keep-alive interval to prevent disconnection:
+
+```bash
+ssh -o StrictHostKeyChecking=accept-new -o ServerAliveInterval=60 -R 80:localhost:<PORT> tinyfi.sh
+```
+
+## Usage Guidelines
+
+When starting a tunnel for the user:
+
+1. **Ask which port** to expose if not already specified
+2. **Run the SSH command** in the background so the agent can continue working
+3. **Report the public URL** back to the user once the tunnel is established
+4. The tunnel stays open as long as the SSH connection is alive
+
+## Common Ports
+
+| Framework / Tool     | Default Port |
+|----------------------|-------------|
+| Next.js / React / Express | 3000   |
+| Vite                 | 5173        |
+| Django               | 8000        |
+| Flask                | 5000        |
+| Go (net/http)        | 8080        |
+| Ruby on Rails        | 3000        |
+| PHP (built-in)       | 8000        |
+
+## Rate Limits
+
+- 5 SSH connections per minute per IP
+- 100 HTTP requests per minute per IP
+- 50 concurrent connections max
+- 48-hour idle timeout
+
+$ARGUMENTS

--- a/plugins/tinyfish/skills/tunneling/SKILL.md
+++ b/plugins/tinyfish/skills/tunneling/SKILL.md
@@ -17,13 +17,15 @@ which ssh && echo "SSH available" || echo "SSH not found — install OpenSSH fir
 
 ## Quick Start
 
-Expose a local port to the internet:
+**Warning:** This exposes your local service to the public internet. Avoid tunneling admin panels, debug endpoints, or services that expose secrets or credentials.
 
 ```bash
 ssh -o StrictHostKeyChecking=accept-new -R 80:localhost:<PORT> tinyfi.sh
 ```
 
 Replace `<PORT>` with the port your app is running on. The command will print a public `https://<random>.tinyfi.sh` URL.
+
+> **Note:** `StrictHostKeyChecking=accept-new` automatically trusts the tinyfi.sh host key on first connection and rejects changes on subsequent connections. This is safe for typical use but if you require stricter verification, you can manually confirm the server fingerprint before first use.
 
 ## Custom Subdomain
 

--- a/plugins/tinyfish/skills/web-agent/SKILL.md
+++ b/plugins/tinyfish/skills/web-agent/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: web-agent
+description: Automate a task on the web using TinyFish. Use when the user wants to interact with a website — navigate pages, fill out forms, click buttons, extract data, log in to services, or complete any multi-step browser workflow using natural language.
+---
+
+# TinyFish Web Agent
+
+You have access to TinyFish's Web Agent, which can automate real browser interactions on any website using natural language goals.
+
+## Required inputs
+
+1. **URL** — the starting webpage
+2. **Goal** — a plain-language description of what to accomplish
+
+## Choosing the right tool
+
+| Scenario | Tool | Why |
+|----------|------|-----|
+| Single task, want to see progress | `run_web_automation` | Streams real-time updates as the agent works |
+| Fire-and-forget, check results later | `run_web_automation_async` | Returns a `run_id` immediately; check with `get_run` |
+| Same task across many URLs (up to 100) | `batch_create` | Efficient parallel processing |
+
+### Run management tools
+
+- `get_run` — get the status and result of a run by ID
+- `list_runs` — list recent runs, optionally filter by status (`queued`, `running`, `completed`, `failed`, `cancelled`)
+- `cancel_run` — stop a running automation
+- `batch_status` — check progress of a batch
+- `batch_cancel` — cancel all pending runs in a batch
+
+## Optional parameters
+
+Only offer these when relevant — don't ask about all of them every time:
+
+- **`browser_profile`**: `"lite"` (default, fast) or `"stealth"` (anti-bot evasion, slower). Use stealth for sites known to block automation: LinkedIn, major e-commerce, airline booking sites.
+- **`proxy_config`**: `{ "country": "<code>" }` where code is one of: `US`, `GB`, `CA`, `DE`, `FR`, `JP`, `AU`. Only needed for geo-restricted content.
+- **`use_vault`**: `true` if the user has connected a password manager (1Password or Bitwarden) for authenticated workflows.
+- **`credential_item_ids`**: specific vault item IDs to scope which credentials the agent can access.
+
+## Writing effective goals
+
+Always specify the exact JSON structure you want returned. Good goals are specific and action-oriented:
+
+- "Extract all products as JSON array: `[{\"name\": str, \"price\": str, \"url\": str}]`"
+- "Extract the product name, price, availability, and all customer ratings. Return as JSON: `{\"name\": str, \"price\": str, \"in_stock\": bool, \"ratings\": [int]}`"
+- "Fill out the contact form with: Name: John Smith, Email: john@example.com, Message: 'Requesting a demo'. Submit the form."
+- "Log in, navigate to the billing page, and extract the current plan name and next billing date."
+
+Avoid vague goals like "look at this page" or "check this site." Being explicit about the output format produces much more consistent results.
+
+## Parallel extraction
+
+When extracting from multiple independent sites, run separate parallel calls — don't combine them into one goal:
+
+**Good** — parallel calls for each source:
+- Call `run_web_automation_async` for site A → get `run_id_a`
+- Call `run_web_automation_async` for site B → get `run_id_b`
+- Call `run_web_automation_async` for site C → get `run_id_c`
+- Then collect results with `get_run` for each
+
+**Bad** — single combined call:
+- "Go to site A, then site B, then site C and extract data from all of them"
+
+Each independent extraction should be its own API call. This is faster (parallel execution) and more reliable.
+
+For 5+ URLs with the same goal, use `batch_create` instead of individual async calls.
+
+## Important constraints
+
+- Each run has a **10-minute timeout**. For very complex workflows, break them into sequential runs.
+- Every run provides a **`streaming_url`** — share this with the user so they can watch the automation live.
+- The agent operates a real browser. It handles JavaScript rendering, dynamic content, and infinite scroll automatically.
+
+## Handling results
+
+- **Success**: present the extracted data clearly, formatted for the content type (tables for tabular data, JSON for structured data, prose for summaries).
+- **Failure**: check the error message. Common fixes: switch to `stealth` profile, make the goal more specific, add a proxy for geo-restricted sites, break a complex goal into steps.
+- **Partial results**: some runs return useful data even if they didn't fully complete. Check the output before declaring failure.
+
+$ARGUMENTS


### PR DESCRIPTION
## Summary

- Adds a **Claude Code marketplace manifest** to this repo so the TinyFish plugin can be discovered and installed via `claude plugin install`
- Adds the **TinyFish plugin** with MCP server integration (OAuth 2.1) and two skills
- **Zero modifications to existing files** — all additive

## Why this repo?

This repo already hosts TinyFish's active skills and has 1,500+ stars for discoverability. Adding the marketplace manifest here (rather than a separate repo) keeps everything in one place and takes advantage of the existing visibility.

## What's added

```
.claude-plugin/
  marketplace.json               ← Makes this repo a Claude Code marketplace
plugins/tinyfish/
  .claude-plugin/plugin.json     ← Plugin manifest
  .mcp.json                      ← MCP server → agent.tinyfish.ai/mcp (OAuth 2.1)
  skills/web-agent/SKILL.md      ← Browser automation skill (MCP-based)
  skills/tunneling/SKILL.md      ← Local port tunneling skill (tinyfi.sh)
  CHANGELOG.md                   ← v1.0.0
```

## What users get

**8 MCP tools** — `run_web_automation`, `run_web_automation_async`, `get_run`, `list_runs`, `cancel_run`, `batch_create`, `batch_status`, `batch_cancel`

**2 skills** — `/tinyfish:web-agent` (browser automation via natural language), `/tinyfish:tunneling` (expose local ports)

## How users install

```bash
# Add this marketplace
claude plugin marketplace add tinyfish-io/tinyfish-cookbook

# Install the plugin
claude plugin install tinyfish@tinyfish-marketplace
```

Once on the official Anthropic marketplace (submission to follow after merge):
```bash
claude plugin install tinyfish
```

## Validated and tested

```
✔ Marketplace validation passed
✔ Plugin validation passed
✔ 2 skills load correctly
✔ 8 MCP tools discovered and available
```

## Relationship to existing skills/

The standalone skills in `skills/` (like `use-tinyfish`) are **unchanged and complementary**. Those are CLI-based skills that work without MCP. This plugin provides the MCP-native path with OAuth authentication — no API key or CLI installation needed.

## Test plan

- [x] `claude plugin validate .` passes at repo root
- [x] `claude plugin validate ./plugins/tinyfish` passes
- [x] `claude --plugin-dir ./plugins/tinyfish` loads 2 skills + 8 MCP tools
- [ ] OAuth flow completes on first interactive use
- [ ] `run_web_automation` executes successfully against a test URL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * TinyFish plugin (v1.0.0) with web automation capabilities via MCP integration
  * Web-agent skill for natural-language browser automation and workflow tasks
  * Tunneling skill for exposing local ports as public HTTPS URLs via tinyfi.sh
  * Support for both streaming and asynchronous automation runs with batch processing

* **Documentation**
  * Added plugin metadata, configuration, and comprehensive skill documentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->