### PR TITLE
Migration logistic-sentry to Tinyfish SDK 

### DIFF
--- a/logistics-sentry/.env.example
+++ b/logistics-sentry/.env.example
@@ -1,0 +1,3 @@
+# TinyFish Web Agent API key (server-side only)
+# Get yours at: https://agent.tinyfish.ai/api-keys
+TINYFISH_API_KEY=

--- a/logistics-sentry/.env.example
+++ b/logistics-sentry/.env.example
@@ -1,3 +1,4 @@
-# TinyFish Web Agent API key (server-side only)
+# TinyFish Web Agent API key 
 # Get yours at: https://agent.tinyfish.ai/api-keys
-TINYFISH_API_KEY=
+TINYFISH_API_KEY="your_api_key_here"
+

--- a/logistics-sentry/.gitignore
+++ b/logistics-sentry/.gitignore
@@ -1,5 +1,21 @@
-.env.local
+# Dependencies
 node_modules/
+
+# Next.js
 .next/
+out/
+
+# Environment files
+.env
+.env.local
+.env.*.local
+
+# Build outputs
 *.tsbuildinfo
+
+# Vercel
 .vercel
+
+# OS
+.DS_Store
+Thumbs.db

--- a/logistics-sentry/.gitignore
+++ b/logistics-sentry/.gitignore
@@ -1,0 +1,5 @@
+.env.local
+node_modules/
+.next/
+*.tsbuildinfo
+.vercel

--- a/logistics-sentry/README.md
+++ b/logistics-sentry/README.md
@@ -1,39 +1,76 @@
-# TinyFish - Logistics Intelligence Sentry
-Live Demo: [https://inventory-agent-three.vercel.app/](https://inventory-agent-three.vercel.app/)
+# Logistics Sentry
+**Live Demo: https://inventory-agent-three.vercel.app/**
 
-A comprehensive logistics intelligence platform that helps supply chain teams track port congestion, carrier advisories, and operational risks across multiple sources simultaneously. Uses the **Discovery → Scouting → Synthesis** pipeline pattern with parallel TinyFish browser agents to provide real-time, source-backed operational signals.
+**Logistics intelligence platform — parallel TinyFish agents track port congestion, carrier advisories, and competitive pricing in real time.**
 
-## Demo
-![Demo Video](Demo%20Video.mp4)
+Supply chain teams use Logistics Sentry to monitor operational risks across multiple ports and carriers simultaneously. The app uses a Discovery → Scouting → Synthesis pipeline: the Search API finds official URLs for unknown ports and carriers, then Agent API browser sessions navigate those pages, extract structured signals, and stream results back for risk scoring.
 
-## How TinyFish API is Used
-The TinyFish API powers the core execution layer. The orchestrator deploys **multiple TinyFish Agents** to navigate the live DOM of target logistics sites, bypassing static API limitations. These agents extract "Deep Metrics" (wait times, vessel counts, specific alerts) and return structured operational signals.
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                      Browser (Client)                       │
+│                                                             │
+│  InventoryInput → RiskAssessment → ActivityFeed             │
+│  LiveStream (agent terminal) → DecisionReasoning            │
+└──────────────────────────┬──────────────────────────────────┘
+                           │
+          ┌────────────────┼──────────────────┐
+          ▼                ▼                  ▼
+  POST /api/agent/run  POST /api/pricing/run  POST /api/logistics/risk-assessment
+          │                │                  │
+          ▼                ▼                  ▼
+┌──────────────────────────────────────────────────────────────┐
+│               lib/tinyfish.js  (shared SDK wrapper)          │
+│                                                              │
+│  client.agent.stream({ url, goal, browser_profile: "stealth" })│
+│  EventType.COMPLETE + RunStatus.COMPLETED → validate result  │
+│  // COMPLETED only means browser ran — always validate result │
+└──────────────────────────────────────────────────────────────┘
+```
+
+### Two TinyFish APIs — each for what it does best
+
+```
+Search API  → client.search.query({ query })
+              Used in logistics/agent.js when port or carrier is NOT
+              in SOURCE_KNOWLEDGE_BASE — finds official URLs directly
+              instead of sending an agent to a search engine
+
+Agent API   → client.agent.stream({ url, goal, browser_profile: "stealth" })
+              Used for all three routes — navigates live pages,
+              extracts structured signals JSON, streams events via SSE
+```
 
 ## Intelligence Lifecycle
-The following sequence diagram illustrates the end-to-end flow of a risk assessment, from discovery to synthesis.
 
 ```mermaid
 sequenceDiagram
     participant User
     participant API as Orchestrator (API)
     participant KB as Knowledge Base
-    participant TinyFish as TinyFish Agents
+    participant Search as TinyFish Search API
+    participant Agent as TinyFish Agent API
     participant Web as Live Logistics Web
     participant Logic as Risk Engine
 
     User->>API: POST /risk-assessment (Context)
     API->>KB: Resolve Target URLs
-    Note right of API: Discovery mode triggered if no matches
-    
-    API->>TinyFish: Spawn Parallel Swarm (URL + Mission)
-    
-    par Agent Orchestration
-        TinyFish->>Web: Navigate & Analyze DOM
-        Web-->>TinyFish: HTML Content
-        TinyFish->>TinyFish: Extract Metrics & Quotes
+
+    alt Port/Carrier not in Knowledge Base
+        API->>Search: Search for official URLs
+        Search-->>API: Ranked results with URLs
     end
-    
-    TinyFish-->>API: Return Structured Signals (JSON)
+
+    API->>Agent: Spawn Parallel Swarm (URL + Mission)
+
+    par Agent Orchestration
+        Agent->>Web: Navigate & Analyze DOM
+        Web-->>Agent: HTML Content
+        Agent->>Agent: Extract Metrics & Quotes
+    end
+
+    Agent-->>API: Return Structured Signals (JSON)
     API->>Logic: Synthesize Findings
     Logic->>Logic: Apply Decision Matrix
     Logic-->>API: Consolidated Risk Profile
@@ -41,82 +78,127 @@ sequenceDiagram
 ```
 
 ## Risk Decision Logic
-The system normalizes unstructured signals into a coherent risk level based on the following state logic.
 
 ```mermaid
 stateDiagram-v2
     [*] --> Scanning
-    
+
     Scanning --> Normal: No Negative Signals Found
     Scanning --> SignalsDetected: Metrics/Quotes Extracted
-    
+
     SignalsDetected --> LowRisk: Minor Congestion (wait < 2 days)
     SignalsDetected --> MediumRisk: Moderate Congestion (wait 2-4 days)
     SignalsDetected --> HighRisk: Strike / Force Majeure / Severe Wait (> 4 days)
-    
+
     LowRisk --> Monitoring: "Continue monitoring"
     MediumRisk --> AlertSubscriber: "Anticipate berthing delay"
     HighRisk --> CrisisAction: "Divert cargo immediately"
-    
+
     Normal --> [*]
     Monitoring --> [*]
     AlertSubscriber --> [*]
     CrisisAction --> [*]
 ```
 
-## Code Snippet
+## Three API Routes
+
+| Route | Purpose |
+|---|---|
+| `POST /api/agent/run` | Inventory audit agent — deep integrity check for a given SKU |
+| `POST /api/pricing/run` | Competitive pricing intelligence — extracts pricing tiers from competitor pages |
+| `POST /api/logistics/risk-assessment` | Port + carrier risk — parallel swarm across all monitored nodes |
+
+## Key Patterns
+
+**SOURCE_KNOWLEDGE_BASE fallback** (`lib/logistics/agent.js`) — known high-traffic ports and carriers (Port of LA, Shanghai, Mumbai, Maersk, MSC) have pre-mapped URLs. Unknown ports/carriers fall back to `client.search.query()` to discover official URLs before scouting.
+
+**Concurrency-limited parallel agents** (`lib/pricing-intelligence.js`) — `MAX_CONCURRENCY = 5`, per-agent `AbortController` with 35s timeout, custom SSE-to-SSE proxy so results stream back to the client as each agent finishes.
+
+**Educational comment in `lib/tinyfish.js:80-82`:**
 ```javascript
-// Example: Requesting a Risk Assessment in the Logistics Sentry
-const response = await fetch("/api/logistics/risk-assessment", {
-  method: "POST",
-  headers: { "Content-Type": "application/json" },
-  body: JSON.stringify({
-    origin_port: "Port of Los Angeles",
-    carrier: "Maersk",
-    mode: "Sea Freight"
-  }),
-});
-
-const data = await response.json();
-// Returns a structured Risk Profile with confidence scores and root causes
+// COMPLETED only means the browser ran without crashing
+// — always validate result content, not just the status.
 ```
 
-## How to Run
+## Setup
+
 ### Prerequisites
+
 - Node.js 18+
-- TinyFish API key (get from [tinyfish.ai](https://tinyfish.ai))
+- TinyFish API key
 
-### Setup
-1. **Install dependencies**:
-   ```bash
-   npm install
-   ```
-2. **Configure Environment**:
-   Create a `.env.local` file with:
-   ```bash
-   TINYFISH_API_KEY=xxx
-   ```
-3. **Run development server**:
-   ```bash
-   npm run dev
-   ```
+### Environment Variables
 
-## Architecture Diagram
-```mermaid
-graph TD
-    UI[USER INTERFACE<br/>Next.js 14 + Framer Motion]
-    API[Risk Orchestrator<br/>api/logistics/risk-assessment]
-    
-    TinyFish[TINYFISH BROWSER AGENTS<br/>Execution Layer]
-    Web[LIVE PUBLIC WEB<br/>Ports / Carriers / Alerts]
-    Logic[RISK ENGINE<br/>Synthesis & Decisioning]
-    
-    UI -->|Route Context| API
-    API -->|1. Discovery| API
-    API -->|2. Parallel Swarm| TinyFish
-    TinyFish -->|3. Scrape & Reason| Web
-    Web -->|Unstructured Data| TinyFish
-    TinyFish -->|Structured Signals| Logic
-    Logic -->|JSON Risk Profile| API
-    API -->|4. Assessment| UI
+```bash
+cp .env.example .env.local
 ```
+
+Then fill in:
+
+```env
+# TinyFish Web Agent API key (server-side only)
+# Get yours at: https://agent.tinyfish.ai/api-keys
+TINYFISH_API_KEY=your-tinyfish-api-key
+```
+
+### Install & Run
+
+```bash
+npm install
+npm run dev
+```
+
+Open http://localhost:3000
+
+## Project Structure
+
+```
+logistics-sentry/
+├── src/
+│   ├── app/
+│   │   ├── layout.js
+│   │   ├── page.js                          # Main dashboard
+│   │   ├── globals.css
+│   │   ├── competitive-pricing/page.js      # Pricing intelligence page
+│   │   └── api/
+│   │       ├── agent/run/route.js           # Inventory audit agent
+│   │       ├── pricing/run/route.js         # Competitive pricing agent
+│   │       └── logistics/risk-assessment/   # Port + carrier risk swarm
+│   ├── components/
+│   │   ├── RiskAssessment.js
+│   │   ├── ActivityFeed.js
+│   │   ├── LiveStream.js                    # Agent terminal
+│   │   ├── DecisionReasoning.js
+│   │   ├── InventoryInput.js
+│   │   ├── InventoryAlert.js
+│   │   ├── MetricCard.js
+│   │   ├── ActionPanel.js
+│   │   ├── AgentHeader.js
+│   │   └── TinyFishAgentAesthetics.js
+│   └── lib/
+│       ├── tinyfish.js                      # Shared SDK wrapper (Search + Agent)
+│       ├── logistics/agent.js               # KB lookup + Search API fallback
+│       ├── pricing-intelligence.js          # Concurrent pricing agents
+│       ├── decision-engine.js               # Risk scoring + decision matrix
+│       └── utils.js
+├── .env.example
+├── .gitignore
+└── package.json
+```
+
+## Constraint Checklist
+
+| Constraint | Status |
+|---|---|
+| External database used? | NO (pure in-memory) |
+| Both TinyFish APIs used? | YES (Search for discovery, Agent for scouting) |
+| Parallel agents? | YES (`Promise.allSettled` across ports + carriers) |
+| Concurrency limited? | YES (`MAX_CONCURRENCY = 5` in pricing intelligence) |
+| Result validation? | YES (COMPLETED status ≠ goal achieved — content always validated) |
+| Cancellation support? | YES (per-agent `AbortController` with 35s timeout) |
+
+## Tech Stack
+
+- **Framework:** Next.js 14 (App Router), JavaScript, Tailwind CSS
+- **Browser Agents:** TinyFish SDK (`client.agent.stream`, `client.search.query`)
+- **Deployment:** Vercel

--- a/logistics-sentry/package-lock.json
+++ b/logistics-sentry/package-lock.json
@@ -1,13 +1,14 @@
 {
-  "name": "inventory-risk-agent",
+  "name": "logistics-sentry",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "inventory-risk-agent",
+      "name": "logistics-sentry",
       "version": "0.1.0",
       "dependencies": {
+        "@tiny-fish/sdk": "latest",
         "clsx": "^2.1.1",
         "framer-motion": "^11.18.2",
         "lucide-react": "^0.378.0",
@@ -519,6 +520,18 @@
       "dependencies": {
         "@swc/counter": "^0.1.3",
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tiny-fish/sdk": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@tiny-fish/sdk/-/sdk-0.0.7.tgz",
+      "integrity": "sha512-VzBTKwYfJZEkNpj56kyBGnT6m8DNaXdDSaDImTC6t/9IyIcXguqrB83pyioRs23vIhQs+soNs8vgYASALDmtsA==",
+      "dependencies": {
+        "p-retry": "^7.1.1",
+        "zod": "^4.3.6"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@tybys/wasm-util": {
@@ -3413,6 +3426,18 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-network-error": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/is-network-error/-/is-network-error-1.3.1.tgz",
+      "integrity": "sha512-6QCxa49rQbmUWLfk0nuGqzql9U8uaV2H6279bRErPBHe/109hCzsLUBUHfbEtvLIHBd6hyXbgedBSHevm43Edw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -4283,6 +4308,21 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-retry": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-7.1.1.tgz",
+      "integrity": "sha512-J5ApzjyRkkf601HpEeykoiCvzHQjWxPAHhyjFcEUP2SWq0+35NKh8TLhpLw+Dkq5TZBFvUM6UigdE9hIVYTl5w==",
+      "license": "MIT",
+      "dependencies": {
+        "is-network-error": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -6083,6 +6123,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/logistics-sentry/package.json
+++ b/logistics-sentry/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "inventory-risk-agent",
+  "name": "logistics-sentry",
   "version": "0.1.0",
   "private": true,
   "scripts": {
@@ -9,6 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@tiny-fish/sdk": "latest",
     "clsx": "^2.1.1",
     "framer-motion": "^11.18.2",
     "lucide-react": "^0.378.0",

--- a/logistics-sentry/src/lib/logistics/agent.js
+++ b/logistics-sentry/src/lib/logistics/agent.js
@@ -1,4 +1,5 @@
 import { runGenericAgent } from "../tinyfish";
+import { TinyFish } from "@tiny-fish/sdk";
 
 // --- STAGE 1: SOURCE DISCOVERY (KNOWLEDGE BASE) ---
 // In a production system, this would be an LLM or specific search agent.
@@ -58,74 +59,46 @@ const SOURCE_KNOWLEDGE_BASE = {
     // Contextual sources like Weather or Labor generic sites could be added
 };
 
-function buildDiscoverySources(origin_port, carrier) {
+async function buildDiscoverySources(origin_port, carrier) {
+    const client = new TinyFish({ apiKey: process.env.TINYFISH_API_KEY });
     const sources = [];
+
     if (origin_port) {
-        const portQuery = encodeURIComponent(`${origin_port} port authority operations status`);
-        sources.push({
-            name: `Discovery: ${origin_port} Port Authority`,
-            url: `https://duckduckgo.com/html/?q=${portQuery}`,
-            type: "custom_discovery",
-            goal: `
-### MISSION: PORT AUTHORITY INTELLIGENCE DISCOVERY
-TARGET: ${origin_port}
-
-You are a Logistics Intelligence Scout. Your job is to locate the official port authority or terminal operations page for ${origin_port}, then extract operational status signals.
-
-### INSTRUCTIONS:
-1. Search for the official port authority or terminal operations page for ${origin_port}.
-2. Navigate to the official source and look for operational updates, advisories, or congestion metrics.
-3. Extract specific metrics/quotes with dates where possible.
-
-### REQUIRED OUTPUT (JSON ONLY):
-{
-  "scan_status": "completed",
-  "operational_status": "NORMAL" | "DISRUPTED" | "UNKNOWN",
-  "signals": [
-    {
-      "summary": "Detailed finding with numbers/quotes if available",
-      "severity": "LOW" | "MEDIUM" | "HIGH",
-      "date": "YYYY-MM-DD",
-      "category": "METRIC" | "QUOTE" | "STATUS"
+        try {
+            const res = await client.search.query({
+                query: `${origin_port} port authority operations status advisories`,
+            });
+            const top = res.results?.slice(0, 2) || [];
+            top.forEach((r) => {
+                sources.push({
+                    name: r.title || `Discovery: ${origin_port}`,
+                    url: r.url,
+                    type: "port_authority",
+                });
+            });
+        } catch (e) {
+            console.error(`[Search] Port discovery failed for ${origin_port}:`, e.message);
+        }
     }
-  ]
-}
-`
-        });
-    }
+
     if (carrier) {
-        const carrierQuery = encodeURIComponent(`${carrier} customer advisories`);
-        sources.push({
-            name: `Discovery: ${carrier} Advisories`,
-            url: `https://duckduckgo.com/html/?q=${carrierQuery}`,
-            type: "custom_discovery",
-            goal: `
-### MISSION: CARRIER ADVISORY INTELLIGENCE DISCOVERY
-TARGET: ${carrier}
-
-You are a Logistics Intelligence Scout. Your job is to locate ${carrier}'s official customer advisories or operations updates page, then extract operational signals.
-
-### INSTRUCTIONS:
-1. Find the official ${carrier} advisories/alerts/newsroom page.
-2. Navigate to the most recent advisories and extract concrete metrics or dates.
-3. Prefer official carrier sources over third-party news.
-
-### REQUIRED OUTPUT (JSON ONLY):
-{
-  "scan_status": "completed",
-  "operational_status": "NORMAL" | "DISRUPTED" | "UNKNOWN",
-  "signals": [
-    {
-      "summary": "Detailed finding with numbers/quotes if available",
-      "severity": "LOW" | "MEDIUM" | "HIGH",
-      "date": "YYYY-MM-DD",
-      "category": "METRIC" | "QUOTE" | "STATUS"
+        try {
+            const res = await client.search.query({
+                query: `${carrier} shipping customer advisories operational updates`,
+            });
+            const top = res.results?.slice(0, 2) || [];
+            top.forEach((r) => {
+                sources.push({
+                    name: r.title || `Discovery: ${carrier}`,
+                    url: r.url,
+                    type: "carrier_advisory",
+                });
+            });
+        } catch (e) {
+            console.error(`[Search] Carrier discovery failed for ${carrier}:`, e.message);
+        }
     }
-  ]
-}
-`
-        });
-    }
+
     return sources;
 }
 
@@ -447,7 +420,7 @@ export async function assessDelayRisk(context) {
 
     let discoveryUsed = false;
     if (sources.length === 0) {
-        sources = buildDiscoverySources(origin_port, carrier);
+        sources = await buildDiscoverySources(origin_port, carrier);
         discoveryUsed = sources.length > 0;
         if (!discoveryUsed) {
             return {

--- a/logistics-sentry/src/lib/pricing-intelligence.js
+++ b/logistics-sentry/src/lib/pricing-intelligence.js
@@ -1,13 +1,14 @@
 "use server";
 
-const TINYFISH_API_URL = "https://tinyfish.ai/v1/automation/run-sse";
-const TINYFISH_API_KEY = process.env.TINYFISH_API_KEY;
+import { TinyFish, EventType, RunStatus } from "@tiny-fish/sdk";
+
+const client = new TinyFish({ apiKey: process.env.TINYFISH_API_KEY });
 
 export async function runPricingAnalysis(competitorUrl, options = {}) {
-  if (!TINYFISH_API_KEY) throw new Error("Missing TINYFISH_API_KEY environment variable");
-  if (!competitorUrl) throw new Error("Missing competitorUrl");
+    if (!process.env.TINYFISH_API_KEY) throw new Error("Missing TINYFISH_API_KEY environment variable");
+    if (!competitorUrl) throw new Error("Missing competitorUrl");
 
-  const goal = `
+    const goal = `
 ### MISSION: COMPETITIVE PRICING INTELLIGENCE (Target: ${competitorUrl})
 
 You are a senior Strategic Pricing Analyst. Your mission is to extract the exact pricing and packaging model for the specified competitor.
@@ -61,28 +62,39 @@ You are a senior Strategic Pricing Analyst. Your mission is to extract the exact
 }
 `;
 
-  try {
-    const response = await fetch(TINYFISH_API_URL, {
-      method: "POST",
-      headers: {
-        "X-API-Key": TINYFISH_API_KEY,
-        "Content-Type": "application/json",
-      },
-      signal: options.signal,
-      body: JSON.stringify({
-        url: competitorUrl,
-        goal: goal,
-        browser_profile: "stealth"
-      }),
+    const encoder = new TextEncoder();
+
+    // Return a ReadableStream compatible with the existing pricing/run/route.js
+    // SSE parser — it reads raw "data: ..." lines and looks for final_result.
+    return new ReadableStream({
+        async start(controller) {
+            const sendEvent = (data) => {
+                controller.enqueue(encoder.encode(`data: ${JSON.stringify(data)}\n\n`));
+            };
+
+            try {
+                const stream = await client.agent.stream(
+                    { url: competitorUrl, goal, browser_profile: "stealth" },
+                    { signal: options.signal }
+                );
+
+                for await (const event of stream) {
+                    sendEvent(event);
+
+                    if (event.type === EventType.COMPLETE) {
+                        if (event.status === RunStatus.COMPLETED) {
+                            // TypeScript SDK: event.result (not event.result_json)
+                            sendEvent({ final_result: event.result ?? null });
+                        }
+                        break; // always break after COMPLETE
+                    }
+                }
+            } catch (error) {
+                console.error(`Agent execution failed for ${competitorUrl}:`, error);
+                sendEvent({ type: "error", message: error.message });
+            } finally {
+                controller.close();
+            }
+        },
     });
-
-    if (!response.ok) {
-      throw new Error(`TinyFish API error for ${competitorUrl}: ${response.statusText}`);
-    }
-
-    return response.body;
-  } catch (error) {
-    console.error(`Agent execution failed for ${competitorUrl}:`, error);
-    throw error;
-  }
 }

--- a/logistics-sentry/src/lib/tinyfish.js
+++ b/logistics-sentry/src/lib/tinyfish.js
@@ -1,17 +1,20 @@
 "use server";
 
-const TINYFISH_API_URL = "https://tinyfish.ai/v1/automation/run-sse";
-const TINYFISH_API_KEY = process.env.TINYFISH_API_KEY;
+import { TinyFish, EventType, RunStatus } from "@tiny-fish/sdk";
+
+const client = new TinyFish({ apiKey: process.env.TINYFISH_API_KEY });
 
 export async function runAgent(sku, intendedUpdate, contextUrl, options = {}) {
     const targetUrl = contextUrl || "https://inventory-demo-dashboard.com";
-    const missionType = intendedUpdate ? `cross-verify the safety of an intended stock update ("${intendedUpdate}")` : `perform a general integrity audit to ensure data consistency across sources`;
+    const missionType = intendedUpdate
+        ? `cross-verify the safety of an intended stock update ("${intendedUpdate}")`
+        : `perform a general integrity audit to ensure data consistency across sources`;
 
     const goal = `
 ### MISSION: DEEP INTEGRITY AUDIT (SKU: ${sku})
 
 You are a senior Autonomous Inventory Auditor. Your mission is to ${missionType} by investigating multiple data sources.
-${contextUrl ? `\n**CRITICAL CONTEXT**: The user has provided a specific Source of Truth URL: ${contextUrl}. You MUST navigate to this URL to verify the "Actual Stock" against the dashboard's "Reported Stock".\n` : ''}
+${contextUrl ? `\n**CRITICAL CONTEXT**: The user has provided a specific Source of Truth URL: ${contextUrl}. You MUST navigate to this URL to verify the "Actual Stock" against the dashboard's "Reported Stock".\n` : ""}
 
 ### AUDIT PHASES
 1. **PHASE_1: SURFACE_SCAN (Dashboard)**
@@ -20,12 +23,16 @@ ${contextUrl ? `\n**CRITICAL CONTEXT**: The user has provided a specific Source 
    - Report: {"phase": "SURFACE_SCAN", "status": "completed", "findings": "Extracted reported stock"}
 
 2. **PHASE_2: SOURCE_VERIFICATION (Audit Logs / External Source)**
-   ${contextUrl ? `- **Navigate to the provided Source URL**: ${contextUrl}\n   - Search for ${sku} in the external sheet/feed.\n   - Compare the "Stock" value there with the Dashboard value.` : `- Find and navigate to the "Audit Logs" or "History" section.\n   - Search for ${sku} and check the last 5 manual entries.\n   - Identify if the "User ID" or "Source" of recent changes looks suspicious or anomalous.`}
+   ${contextUrl
+        ? `- **Navigate to the provided Source URL**: ${contextUrl}\n   - Search for ${sku} in the external sheet/feed.\n   - Compare the "Stock" value there with the Dashboard value.`
+        : `- Find and navigate to the "Audit Logs" or "History" section.\n   - Search for ${sku} and check the last 5 manual entries.\n   - Identify if the "User ID" or "Source" of recent changes looks suspicious or anomalous.`}
    - Report: {"phase": "SOURCE_VERIFICATION", "status": "completed", "findings": "Verified log/source integrity"}
 
 3. **PHASE_3: BUSINESS_CONTEXT (Sales Analytics)**
    - Navigate to "Sales Analytics" or "Orders" view.
-   ${intendedUpdate ? `- Determine if the "Sales Velocity" for ${sku} justifies the intended update: "${intendedUpdate}".\n   - Check for pending shipments that might conflict with this update.` : `- Analyze "Sales Velocity" for ${sku} to detect any anomalies vs reported stock.\n   - Identify if current stock levels are dangerously low or high based on sales trends.`}
+   ${intendedUpdate
+        ? `- Determine if the "Sales Velocity" for ${sku} justifies the intended update: "${intendedUpdate}".\n   - Check for pending shipments that might conflict with this update.`
+        : `- Analyze "Sales Velocity" for ${sku} to detect any anomalies vs reported stock.\n   - Identify if current stock levels are dangerously low or high based on sales trends.`}
    - Report: {"phase": "BUSINESS_CONTEXT", "status": "completed", "findings": "Analyzed sales alignment"}
 
 4. **PHASE_4: SYNTHESIS & VERDICT**
@@ -50,56 +57,76 @@ ${contextUrl ? `\n**CRITICAL CONTEXT**: The user has provided a specific Source 
 }
 `;
 
-    try {
-        const response = await fetch(TINYFISH_API_URL, {
-            method: "POST",
-            headers: {
-                "X-API-Key": TINYFISH_API_KEY,
-                "Content-Type": "application/json",
-            },
-            signal: options.signal,
-            body: JSON.stringify({
-                url: targetUrl,
-                goal: goal,
-                browser_profile: "stealth"
-            }),
-        });
+    // Return a ReadableStream that mirrors SDK SSE events so the existing
+    // API route can pass it through unchanged to the browser.
+    const encoder = new TextEncoder();
 
-        if (!response.ok) {
-            throw new Error(`TinyFish API error: ${response.statusText}`);
-        }
+    return new ReadableStream({
+        async start(controller) {
+            const sendEvent = (data) => {
+                controller.enqueue(encoder.encode(`data: ${JSON.stringify(data)}\n\n`));
+            };
 
-        // Since this is SSE, we return the stream or a reader
-        return response.body;
-    } catch (error) {
-        console.error("Agent execution failed:", error);
-        throw error;
-    }
+            try {
+                const stream = await client.agent.stream(
+                    { url: targetUrl, goal, browser_profile: "stealth" },
+                    { signal: options.signal }
+                );
+
+                for await (const event of stream) {
+                    sendEvent(event);
+
+                    if (event.type === EventType.COMPLETE) {
+                        // COMPLETED only means the browser ran without crashing —
+                        // always validate result content, not just the status.
+                        if (event.status === RunStatus.COMPLETED) {
+                            // TypeScript SDK: event.result (not event.result_json)
+                            sendEvent({ final_result: event.result ?? null });
+                        }
+                        break; // always break after COMPLETE
+                    }
+                }
+            } catch (error) {
+                console.error("Agent execution failed:", error);
+                sendEvent({ type: "error", message: error.message });
+            } finally {
+                controller.close();
+            }
+        },
+    });
 }
 
 export async function runGenericAgent(url, goal, options = {}) {
-    try {
-        const response = await fetch(TINYFISH_API_URL, {
-            method: "POST",
-            headers: {
-                "X-API-Key": TINYFISH_API_KEY,
-                "Content-Type": "application/json",
-            },
-            signal: options.signal,
-            body: JSON.stringify({
-                url: url,
-                goal: goal,
-                browser_profile: "stealth"
-            }),
-        });
+    const encoder = new TextEncoder();
 
-        if (!response.ok) {
-            throw new Error(`TinyFish API error: ${response.statusText}`);
-        }
+    return new ReadableStream({
+        async start(controller) {
+            const sendEvent = (data) => {
+                controller.enqueue(encoder.encode(`data: ${JSON.stringify(data)}\n\n`));
+            };
 
-        return response.body;
-    } catch (error) {
-        console.error("Agent execution failed:", error);
-        throw error;
-    }
+            try {
+                const stream = await client.agent.stream(
+                    { url, goal, browser_profile: "stealth" },
+                    { signal: options.signal }
+                );
+
+                for await (const event of stream) {
+                    sendEvent(event);
+
+                    if (event.type === EventType.COMPLETE) {
+                        if (event.status === RunStatus.COMPLETED) {
+                            sendEvent({ final_result: event.result ?? null });
+                        }
+                        break; // always break after COMPLETE
+                    }
+                }
+            } catch (error) {
+                console.error("Agent execution failed:", error);
+                sendEvent({ type: "error", message: error.message });
+            } finally {
+                controller.close();
+            }
+        },
+    });
 }


### PR DESCRIPTION
Migrates Logistics Sentry from raw TinyFish HTTP calls to the official SDK across all three API routes. The app uses both the Search API (to discover official port and carrier URLs when they're not in the knowledge base) and the Agent API (to navigate those pages and extract structured risk signals).
Fixes the leaked .env.local — key has been rotated by @simantak-dabhade. .gitignore added so this can't happen again. env.example renamed to .env.example with the get-your-key URL comment. Package name corrected from inventory-risk-agent to logistics-sentry. README completed — the previous version ended mid-sentence at step 2 of setup.