### PR TITLE
Restore original cookbook banner

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,8 @@
 # The TinyFish Cookbook
 
-<div align="center">
-  <br />
-  <img width="400" alt="TinyFish Hackathon QR" src="https://i.imgur.com/8KwRGrK.png" />
-  <br /><br />
-</div>
+<a href="https://www.tinyfish.ai/accelerator">
+  <img width="1034" height="407" alt="CKBOOK" src="https://github.com/user-attachments/assets/ce4fccb9-70b8-4023-8022-4e8e3b244fbe" />
+</a>
 
 <div align="center">
 


### PR DESCRIPTION
## Summary
- Swap hackathon QR code back to the original accelerator banner
- All other README changes (featured recipes table, removed SOTA/What is TinyFish sections) stay as-is