### PR TITLE
Fix district-rent-shark: remove broken VN proxy, fix live preview

### DIFF
--- a/district-rent-shark/README.md
+++ b/district-rent-shark/README.md
@@ -23,7 +23,7 @@ Select a city (HCMC, Hanoi, or Da Nang). The app fires parallel browser agents a
                   ▼                 ▼
 ┌─────────────────────────────────────────────────────────────┐
 │                    TinyFish SDK                             │
-│  browser_profile: STEALTH  +  proxy_config: VN              │
+│  browser_profile: STEALTH                                    │
 │                                                             │
 │  /api/search — parallel agents (Promise.allSettled)         │
 │    Agent → chotot.com/HCMC listings                         │
@@ -143,7 +143,7 @@ district-rent-shark/
 |---|---|
 | External database used? | NO (pure in-memory, Supabase fully removed) |
 | Cache layer used? | NO (all results fetched live) |
-| Stealth + proxy for protected sites? | YES (`BrowserProfile.STEALTH` + `proxy_config: VN`) |
+| Stealth for protected sites? | YES (`BrowserProfile.STEALTH`) |
 | Rental agents parallel? | YES (`Promise.allSettled` across sites) |
 | Vibe agents staggered? | YES (2s between districts — Google Maps anti-bot) |
 | Live browser preview? | YES (`STREAMING_URL` → iframe per agent) |
@@ -153,7 +153,7 @@ district-rent-shark/
 ## Tech Stack
 
 - **Framework:** Next.js 16 (App Router), TypeScript, Tailwind CSS 4
-- **Browser Agents:** TinyFish SDK (`client.agent.stream`, stealth + VN proxy)
+- **Browser Agents:** TinyFish SDK (`client.agent.stream`, stealth mode)
 - **Map:** Mapbox GL + react-map-gl (optional)
 - **Icons:** Lucide React
 - **Tests:** Vitest

--- a/district-rent-shark/src/app/api/search/route.ts
+++ b/district-rent-shark/src/app/api/search/route.ts
@@ -3,8 +3,6 @@ export const maxDuration = 800;
 
 import {
   BrowserProfile,
-  type ProxyConfig,
-  ProxyCountryCode,
   RunStatus,
   TinyFish,
 } from "@tiny-fish/sdk";
@@ -14,10 +12,6 @@ import {
 // ---------------------------------------------------------------------------
 
 const REQUEST_TIMEOUT_MS = 780_000;
-const TINYFISH_PROXY_CONFIG: ProxyConfig = {
-  enabled: true,
-  country_code: "VN" as unknown as ProxyCountryCode,
-};
 
 const CITY_SITES: Record<string, string[]> = {
   hcmc: [
@@ -104,7 +98,6 @@ async function runAgentForSite(
       url,
       goal: GOAL_PROMPT,
       browser_profile: BrowserProfile.STEALTH,
-      proxy_config: TINYFISH_PROXY_CONFIG,
     });
 
     let resultJson: unknown;

--- a/district-rent-shark/src/app/api/vibe/route.ts
+++ b/district-rent-shark/src/app/api/vibe/route.ts
@@ -3,8 +3,6 @@ export const maxDuration = 800;
 
 import {
   BrowserProfile,
-  type ProxyConfig,
-  ProxyCountryCode,
   RunStatus,
   TinyFish,
 } from "@tiny-fish/sdk";
@@ -15,10 +13,6 @@ import {
 
 const REQUEST_TIMEOUT_MS = 780_000;
 const REQUEST_STAGGER_MS = 2000; // 2s between districts — Google Maps anti-bot
-const TINYFISH_PROXY_CONFIG: ProxyConfig = {
-  enabled: true,
-  country_code: "VN" as unknown as ProxyCountryCode,
-};
 
 const CITY_DISTRICTS: Record<
   string,
@@ -111,7 +105,6 @@ async function runAgentForDistrict(
       url: mapsUrl,
       goal: buildVibeGoalPrompt(district.name, city),
       browser_profile: BrowserProfile.STEALTH,
-      proxy_config: TINYFISH_PROXY_CONFIG,
     });
 
     let resultJson: unknown;

--- a/district-rent-shark/src/components/live-preview-grid.tsx
+++ b/district-rent-shark/src/components/live-preview-grid.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { useState } from 'react';
 import type { StreamingPreview } from '@/hooks/use-listing-search';
 
 const MAX_VISIBLE = 5;
@@ -14,17 +13,13 @@ interface LivePreviewGridProps {
 }
 
 export function LivePreviewGrid({ previews }: LivePreviewGridProps) {
-  const [expanded, setExpanded] = useState(true);
-
   if (previews.length === 0 || previews.every(p => p.done)) return null;
 
   const activeCount = previews.filter(p => !p.done).length;
   const doneCount   = previews.filter(p =>  p.done).length;
 
-  const active    = previews.filter(p => !p.done);
-  const recent    = [...active].reverse();
-  const visible   = expanded ? recent.slice(0, MAX_VISIBLE) : recent.slice(0, 1);
-  const moreCount = Math.min(active.length, MAX_VISIBLE) - 1;
+  const active  = previews.filter(p => !p.done);
+  const visible = [...active].reverse().slice(0, MAX_VISIBLE);
 
   return (
     <div className="space-y-3">
@@ -33,82 +28,47 @@ export function LivePreviewGrid({ previews }: LivePreviewGridProps) {
           <span className="w-2 h-2 rounded-full bg-red-500 animate-pulse inline-block" />
           Live Browser Agents
         </p>
-        <div className="flex items-center gap-3">
-          <div className="flex items-center gap-3 text-xs">
-            {activeCount > 0 && (
-              <span className="flex items-center gap-1 text-orange-500 font-medium">
-                <span className="w-1.5 h-1.5 rounded-full bg-orange-500 animate-pulse inline-block" />
-                {activeCount} running
-              </span>
-            )}
-            {doneCount > 0 && (
-              <span className="flex items-center gap-1 text-green-600 font-medium">
-                <span className="w-1.5 h-1.5 rounded-full bg-green-500 inline-block" />
-                {doneCount} done
-              </span>
-            )}
-          </div>
-          {moreCount > 0 && (
-            <button
-              type="button"
-              onClick={() => setExpanded(e => !e)}
-              className="text-xs text-zinc-500 hover:text-zinc-800 border border-zinc-200 hover:border-zinc-400 rounded-md px-2.5 py-1 transition-colors"
-            >
-              {expanded ? '− Show less' : `+ Show ${moreCount} more agent${moreCount > 1 ? 's' : ''}`}
-            </button>
+        <div className="flex items-center gap-3 text-xs">
+          {activeCount > 0 && (
+            <span className="flex items-center gap-1 text-orange-500 font-medium">
+              <span className="w-1.5 h-1.5 rounded-full bg-orange-500 animate-pulse inline-block" />
+              {activeCount} running
+            </span>
+          )}
+          {doneCount > 0 && (
+            <span className="flex items-center gap-1 text-green-600 font-medium">
+              <span className="w-1.5 h-1.5 rounded-full bg-green-500 inline-block" />
+              {doneCount} done
+            </span>
           )}
         </div>
       </div>
 
-      <div className={`grid gap-3 ${expanded ? 'grid-cols-2 lg:grid-cols-3' : 'grid-cols-1'}`}>
-        {visible.map(({ siteUrl, streamingUrl, done }) => (
+      <div className="grid gap-3 grid-cols-2 lg:grid-cols-3">
+        {visible.map(({ siteUrl, streamingUrl }) => (
           <div
             key={siteUrl}
-            className={`rounded-xl overflow-hidden border transition-all duration-500 ${
-              done ? 'border-green-200 opacity-60' : 'border-zinc-200 shadow-sm'
-            }`}
+            className="rounded-xl overflow-hidden border border-zinc-200 shadow-sm"
           >
-            <div className={`flex items-center justify-between px-3 py-2 border-b text-xs font-medium ${
-              done ? 'bg-green-50 border-green-100' : 'bg-zinc-100 border-zinc-200'
-            }`}>
+            <div className="flex items-center justify-between px-3 py-2 border-b text-xs font-medium bg-zinc-100 border-zinc-200">
               <span className="truncate text-zinc-700 max-w-[140px]">
                 {getHostname(siteUrl)}
               </span>
-              {done ? (
-                <span className="text-green-600 flex items-center gap-1 shrink-0">
-                  <span className="w-1.5 h-1.5 rounded-full bg-green-500 inline-block" />
-                  Done
-                </span>
-              ) : (
-                <span className="text-orange-500 flex items-center gap-1 shrink-0">
-                  <span className="w-1.5 h-1.5 rounded-full bg-orange-500 animate-pulse inline-block" />
-                  Live
-                </span>
-              )}
+              <span className="text-orange-500 flex items-center gap-1 shrink-0">
+                <span className="w-1.5 h-1.5 rounded-full bg-orange-500 animate-pulse inline-block" />
+                Live
+              </span>
             </div>
             <iframe
               src={streamingUrl}
-              className={`w-full border-0 bg-zinc-50 ${expanded ? 'h-44' : 'h-72'}`}
+              className="w-full border-0 bg-zinc-50 h-44"
               title={`TinyFish agent: ${getHostname(siteUrl)}`}
               loading="eager"
+              sandbox="allow-scripts allow-same-origin"
             />
           </div>
         ))}
       </div>
-
-      {!expanded && moreCount > 0 && (
-        <p className="text-xs text-zinc-400 text-center">
-          {previews.length} agents running in parallel —{' '}
-          <button
-            type="button"
-            onClick={() => setExpanded(true)}
-            className="underline hover:text-zinc-600 transition-colors"
-          >
-            show all
-          </button>
-          <span className="ml-1 text-zinc-300">(may be slow on older devices)</span>
-        </p>
-      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Remove `proxy_config: VN` from both API routes — VN is not a supported proxy country code and causes a 400 Bad Request at runtime
- Add `sandbox="allow-scripts allow-same-origin"` to live preview iframes — fixes blank iframe issue
- Remove confusing show/hide toggle from live preview grid — always show all active agents
- Update README to remove VN proxy claims

## Test plan
- [x] Verified `npm run build` passes
- [x] Tested locally — agents run successfully, live preview iframes render correctly
- [x] Confirmed VN proxy was causing 400 errors from TinyFish API

🤖 Generated with [Claude Code](https://claude.com/claude-code)