### PR TITLE
Fix pharmacy-panic iframe for Safari

### DIFF
--- a/pharmacy-panic/src/components/live-preview-grid.tsx
+++ b/pharmacy-panic/src/components/live-preview-grid.tsx
@@ -92,6 +92,7 @@ export function LivePreviewGrid({ previews }: LivePreviewGridProps) {
               className={`w-full border-0 bg-zinc-50 ${expanded ? 'h-44' : 'h-72'}`}
               title={`TinyFish agent: ${getHostname(siteUrl)}`}
               loading="eager"
+              sandbox="allow-scripts allow-same-origin"
             />
           </div>
         ))}


### PR DESCRIPTION
## Summary
- Add `sandbox="allow-scripts allow-same-origin"` to live preview iframe — fixes blank iframe on Safari

## Test plan
- [x] Verified iframe renders on Safari after fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)