### PR TITLE
Add Raycast TinyFish Search script

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,14 @@ tinyfish fetch content get https://example.com
 
 The CLI writes results to the filesystem instead of piping them through your model's context window — tokens stay low, output stays structured.
 
+### Scripts
+
+Drop TinyFish into everyday tools with small copyable scripts.
+
+| Script | Description |
+|--------|-------------|
+| [Raycast TinyFish Search](./scripts/raycast-tinyfish-search) | Search the web from Raycast and get formatted result URLs, titles, and snippets |
+
 ### Agent Skill
 
 One-line install. Works with Claude Code, Codex, Cursor, OpenCode, Antigravity, and other coding agents. The Skill teaches your agent **when** to reach for Search vs. Fetch vs. Agent, and **how** to call them.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,10 @@
+# TinyFish Scripts
+
+Small, copyable scripts that wire TinyFish into everyday tools.
+
+## Available scripts
+
+| Script | Description |
+|--------|-------------|
+| [raycast-tinyfish-search](./raycast-tinyfish-search) | Raycast Script Command for searching the web with TinyFish and showing formatted result URLs |
+

--- a/scripts/raycast-tinyfish-search/README.md
+++ b/scripts/raycast-tinyfish-search/README.md
@@ -1,0 +1,41 @@
+# TinyFish Search for Raycast
+
+Search the web from Raycast with TinyFish and return formatted result URLs, titles, and snippets.
+
+## Setup
+
+1. Install and authenticate the TinyFish CLI:
+
+   ```bash
+   npm install -g @tiny-fish/cli
+   tinyfish auth login
+   ```
+
+2. Copy `tinyfish-search.sh` into your Raycast Script Commands folder.
+
+3. Make the script executable:
+
+   ```bash
+   chmod +x tinyfish-search.sh
+   ```
+
+4. Open Raycast, run **TinyFish Search**, and type any query.
+
+## Script
+
+The script calls:
+
+```bash
+tinyfish search query "<your query>"
+```
+
+It formats the JSON response into readable search results:
+
+```text
+Results for: raycast extensions
+
+1. Raycast - Your shortcut to everything
+https://www.raycast.com/
+Raycast lets you control your tools with a few keystrokes...
+```
+

--- a/scripts/raycast-tinyfish-search/tinyfish-search.sh
+++ b/scripts/raycast-tinyfish-search/tinyfish-search.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+set -euo pipefail
+
+# Required parameters:
+# @raycast.schemaVersion 1
+# @raycast.title TinyFish Search
+# @raycast.mode fullOutput
+
+# Optional parameters:
+# @raycast.icon 🔎
+# @raycast.description Search the web with TinyFish and list result URLs
+# @raycast.argument1 { "type": "text", "placeholder": "Search query" }
+
+# Documentation:
+# @raycast.author tinyfish
+# @raycast.authorURL https://tinyfish.ai
+
+export PATH="/opt/homebrew/bin:/usr/local/bin:$HOME/.npm-global/bin:$HOME/.local/bin:$PATH"
+
+query="${1:-}"
+
+if [ -z "$query" ]; then
+  echo "Usage: TinyFish Search <query>"
+  exit 1
+fi
+
+TINYFISH_BIN="$(command -v tinyfish || true)"
+if [ -z "$TINYFISH_BIN" ]; then
+  echo "tinyfish not found in PATH"
+  echo
+  echo "Install and authenticate it first:"
+  echo "  npm install -g @tiny-fish/cli"
+  echo "  tinyfish auth login"
+  exit 127
+fi
+
+raw_output="$("$TINYFISH_BIN" search query "$query")"
+
+python3 - "$raw_output" <<'PY'
+import json
+import sys
+
+raw = sys.argv[1].strip()
+data = json.loads(raw)
+query = data.get("query") or "Search"
+results = data.get("results") or []
+
+print(f"Results for: {query}")
+print()
+
+if not results:
+    print("No results found.")
+    sys.exit(1)
+
+for result in results:
+    position = result.get("position") or ""
+    title = result.get("title") or "Untitled"
+    site = result.get("site_name") or ""
+    url = result.get("url") or ""
+    snippet = (result.get("snippet") or "").strip()
+
+    heading = f"{position}. {title}" if position else title
+    if site:
+        heading = f"{heading} ({site})"
+
+    print(heading)
+    if url:
+        print(url)
+    if snippet:
+        print(snippet)
+    print()
+PY


### PR DESCRIPTION
## Summary

Adds a new `scripts/` section to the cookbook with a Raycast Script Command for TinyFish Search.

The script lets users search the web from Raycast using the TinyFish CLI and returns formatted result URLs, titles, site names, and snippets.

## What's included

- `scripts/README.md` as an index for small copyable scripts
- `scripts/raycast-tinyfish-search/tinyfish-search.sh` Raycast Script Command
- `scripts/raycast-tinyfish-search/README.md` with setup and usage instructions
- Root `README.md` link to the new scripts section

## Setup flow for users

1. Install and authenticate the TinyFish CLI:
   ```bash
   npm install -g @tiny-fish/cli
   tinyfish auth login
   ```
2. Copy `tinyfish-search.sh` into the Raycast Script Commands folder.
3. Run `chmod +x tinyfish-search.sh`.
4. Open Raycast, run **TinyFish Search**, and type any query.

## Validation

- Ran `bash -n scripts/raycast-tinyfish-search/tinyfish-search.sh`
- Ran the script locally with `TinyFish AI` and confirmed formatted search results are returned
- Ran `python3 -m json.tool .tags.json`
- Ran `git diff --check`
