### PR TITLE
Attribute OpenClaw CLI usage in the skill

### DIFF
--- a/skills/use-tinyfish/SKILL.md
+++ b/skills/use-tinyfish/SKILL.md
@@ -8,7 +8,8 @@ description: Use TinyFish for web search, fetching URLs, reading pages, current 
 You have access to the TinyFish CLI (`tinyfish`) — a suite of web tools you can call from the terminal.
 
 If not installed: `npm install -g @tiny-fish/cli`
-If not authenticated: `tinyfish auth login --source openclaw` or set `TINYFISH_API_KEY` env var.
+If not authenticated: run `tinyfish auth login --source openclaw`.
+If `TINYFISH_API_KEY` is already set, also set `TINYFISH_CLIENT_HARNESS=openclaw` in the same environment before invoking `tinyfish`.
 
 ---
 


### PR DESCRIPTION
## Summary

- authenticate with `tinyfish auth login --source openclaw` so the CLI can persist OpenClaw attribution
- instruct environment-key users to set `TINYFISH_CLIENT_HARNESS=openclaw` alongside `TINYFISH_API_KEY`

## Why

The API key page URL identifies OpenClaw intent but does not identify subsequent CLI usage. These instructions make the OpenClaw skill opt into the runtime attribution added by the companion `ux-labs` change.

Depends on: https://github.com/tinyfish-io/ux-labs/pull/3631

## Verification

- reviewed the rendered skill instructions and scoped the diff to `skills/use-tinyfish/SKILL.md`
