### PR TITLE
Fix marketplace.json source path resolution bug

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
   "plugins": [
     {
       "name": "tinyfish",
-      "source": "./tinyfish",
+      "source": "./plugins/tinyfish",
       "description": "The complete web toolkit for your agent. Search the web, fetch clean content from URLs, automate browsers with natural language, and spin up headless browsers for full programmatic control.",
       "version": "1.1.0",
       "author": {


### PR DESCRIPTION
## Summary
`source: "./tinyfish"` doesn't exist at the repo root — the plugin lives at `plugins/tinyfish`. `pluginRoot` does not get prepended to an explicit `source` path; it resolves directly from the marketplace root. This has been silently broken since the original submission, unrelated to the MCP migration in #238/#240.

Confirmed via direct testing with `claude plugin marketplace add` + `claude plugin install`:
- Old value (`./tinyfish`): `✘ Failed to install plugin: Source path does not exist: .../tinyfish-cookbook/tinyfish`
- Fixed value (`./plugins/tinyfish`): `✔ Successfully installed plugin`

This is very likely the actual cause of the "Marketplace sync failed" error we hit earlier testing "Add marketplace" against this repo in Claude Desktop.

**Credit:** caught independently by Bryan Thompson (Anthropic) in #239, which also proposed this same fix alongside a broader restructure that overlapped with our own in-flight work. Cherry-picking just this fix here since #239 conflicts with what's already merged.

## Test plan
- [x] `claude plugin validate ./plugins/tinyfish` passes
- [x] `claude plugin install tinyfish@tinyfish-marketplace` succeeds against this branch (failed against unpatched `main`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)