### PR TITLE
docs: correct CLI output behavior in README (fixes #220)

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ tinyfish search query "web automation tools"
 tinyfish fetch content get https://example.com
 ```
 
-The CLI writes results to the filesystem instead of piping them through your model's context window — tokens stay low, output stays structured.
+The CLI prints structured JSON results to **stdout** (your terminal/context window). To keep tokens low and persist output, redirect it to a file yourself, e.g. `tinyfish fetch ... > out.json`.
 
 ### Scripts
 


### PR DESCRIPTION
## Problem
The README (CLI section) claims: `The CLI writes results to the filesystem instead of piping them through your model's context window.`

Actual behavior of `@tiny-fish/cli` (v0.6.1) does **not** match this. The CLI prints structured JSON to **stdout**.

## Evidence
Ran a real command:
```bash
tinyfish fetch content get https://example.com
```
Output was JSON on stdout; **no file was written to the filesystem** (verified by diffing the directory before/after). The npm package description also only states `run web automations from your terminal` with no filesystem-write claim.

## Root cause
Stale/aspirational documentation that no longer reflects the current CLI.

## Solution
Replaced the misleading sentence with an accurate description of stdout output, and showed how users can redirect to a file themselves (`tinyfish fetch ... > out.json`) if they want low-token local persistence.

## Testing
- Rendered README preview; the corrected line reads correctly and markdown is intact.
- Verified the claim matches actual `tinyfish fetch` stdout behavior.

## Expected impact
Removes misleading info so users don't expect filesystem writes that don't happen; improves docs accuracy.

Fixes #220