### PR TITLE
Add recipe conformance check for SSE event-contract drift

### DIFF
--- a/.github/scripts/check_recipes.py
+++ b/.github/scripts/check_recipes.py
@@ -91,7 +91,9 @@ README_REQUIREMENTS = [
     ("demo video or gif", re.compile(r"\.gif\b|\.mp4\b|\bdemo\s*(video|gif)\b|youtube\.com|youtu\.be|loom\.com", re.I)),
     ("TinyFish API snippet", re.compile(r"```[\s\S]*?(tinyfish|TinyFish|agent\.(run|stream))[\s\S]*?```")),
     ("how to run", re.compile(r"\b(how to run|getting started|quick ?start|installation|setup)\b", re.I)),
-    ("environment variables", re.compile(r"[A-Z][A-Z0-9_]{3,}_(API_)?KEY|\.env", re.I)),
+    # Case-insensitivity is scoped to `.env`; the KEY alternative must stay
+    # case-sensitive, or lowercase prose like "turn_key" satisfies it.
+    ("environment variables", re.compile(r"[A-Z][A-Z0-9_]{3,}_(API_)?KEY|(?i:\.env)")),
     ("architecture diagram", re.compile(r"\b(architecture|diagram|flow)\b", re.I)),
 ]
 
@@ -137,11 +139,17 @@ class Problem:
         return f"  [{tag}] {self.location}: {self.message}"
 
 
-def run_git(*args: str) -> str:
+def run_git(*args: str) -> tuple[int, str]:
+    """Return (exit status, stdout).
+
+    Callers must tell empty-and-successful apart from failed. Treating a
+    failed diff as "nothing changed" would make the whole check pass while
+    inspecting nothing, which is the failure CI exists to prevent.
+    """
     result = subprocess.run(
         ["git", *args], cwd=REPO_ROOT, capture_output=True, text=True, check=False
     )
-    return result.stdout if result.returncode == 0 else ""
+    return result.returncode, result.stdout
 
 
 def all_recipes() -> list[Path]:
@@ -170,13 +178,16 @@ def recipe_for(path: Path) -> Path | None:
     return REPO_ROOT / parts[0]
 
 
-def changed_recipes(base: str) -> tuple[list[Path], set[Path]]:
-    """Recipes touched since `base`, and the exact files that changed."""
-    diff = run_git("diff", "--name-only", base)
-    if not diff:
-        merge_base = run_git("merge-base", "HEAD", base).strip()
-        if merge_base:
-            diff = run_git("diff", "--name-only", merge_base)
+def changed_recipes(base: str) -> tuple[list[Path], set[Path], bool]:
+    """Recipes touched since `base`, the files that changed, and whether git
+    could be consulted at all."""
+    status, diff = run_git("diff", "--name-only", base)
+    if status != 0 or not diff:
+        mb_status, merge_base = run_git("merge-base", "HEAD", base)
+        if mb_status == 0 and merge_base.strip():
+            status, diff = run_git("diff", "--name-only", merge_base.strip())
+    if status != 0:
+        return [], set(), False
 
     recipes: dict[Path, None] = {}
     files: set[Path] = set()
@@ -189,7 +200,7 @@ def changed_recipes(base: str) -> tuple[list[Path], set[Path]]:
         owner = recipe_for(rel)
         if owner is not None and owner.is_dir():
             recipes[owner] = None
-    return list(recipes), files
+    return list(recipes), files, True
 
 
 def source_files(recipe: Path) -> list[Path]:
@@ -220,12 +231,52 @@ def read(path: Path) -> str:
 def strip_noise(text: str) -> str:
     """Blank out comments so they cannot fake a match.
 
-    Block comments are replaced by their own newlines rather than removed, so
-    every reported line number still matches the file on disk.
+    Scans with string awareness. A `//` inside a URL literal such as
+    "https://agent.tinyfish.ai/run-sse", or a `/*` inside a string, must not be
+    read as a comment: a regex-only version blanked the rest of that line,
+    hiding real `type:` literals and inventing "no producer emits" findings.
+
+    Block comments become their own newlines rather than disappearing, so every
+    reported line number still matches the file on disk.
+
+    Regex literals are not tracked, so a pattern containing an unescaped `//`
+    can still truncate a line. That is rare in recipe code and strictly better
+    than the previous behaviour.
     """
-    text = re.sub(r"/\*[\s\S]*?\*/", lambda m: "\n" * m.group(0).count("\n"), text)
-    text = re.sub(r"(?m)//.*$", "", text)
-    return text
+    out: list[str] = []
+    i, n = 0, len(text)
+    quote: str | None = None
+    while i < n:
+        ch = text[i]
+        if quote is not None:
+            out.append(ch)
+            if ch == "\\" and i + 1 < n:  # escape inside a string
+                out.append(text[i + 1])
+                i += 2
+                continue
+            if ch == quote:
+                quote = None
+            i += 1
+            continue
+        if ch in "\"'`":
+            quote = ch
+            out.append(ch)
+            i += 1
+            continue
+        if ch == "/" and i + 1 < n and text[i - 1 : i] != "\\":
+            if text[i + 1] == "/":
+                while i < n and text[i] != "\n":
+                    i += 1
+                continue
+            if text[i + 1] == "*":
+                end = text.find("*/", i + 2)
+                end = n if end == -1 else end + 2
+                out.append("\n" * text.count("\n", i, end))
+                i = end
+                continue
+        out.append(ch)
+        i += 1
+    return "".join(out)
 
 
 def line_of(text: str, index: int) -> int:
@@ -401,7 +452,16 @@ def check_env_documented(recipe: Path, files: list[Path]) -> list[Problem]:
         if p.is_file() and not (SKIP_DIR_NAMES & set(p.parts))
     ]
     documented = " ".join(read(p) for p in examples)
-    readme_body = " ".join(read(p) for p in recipe.glob("[Rr]eadme.md"))
+    # Matched case-insensitively by hand: glob("[Rr]eadme.md") misses the
+    # canonical README.md on a case-sensitive filesystem, which is what CI
+    # runs on, so documented vars were never credited there.
+    readme_body = " ".join(
+        read(p) for p in recipe.iterdir()
+        if p.is_file() and p.name.lower() == "readme.md"
+    )
+    # Exact names, not substrings: "API_KEY" must not count as documented
+    # just because the example file mentions "OPENAI_API_KEY".
+    documented_names = set(re.findall(r"\b[A-Z][A-Z0-9_]*\b", documented + " " + readme_body))
 
     used: set[str] = set()
     for path in files:
@@ -412,8 +472,7 @@ def check_env_documented(recipe: Path, files: list[Path]) -> list[Problem]:
         name for name in used
         if name not in ENV_IGNORE_EXACT
         and not name.startswith(ENV_IGNORE_PREFIXES)
-        and name not in documented
-        and name not in readme_body
+        and name not in documented_names
     )
     if not undocumented:
         return []
@@ -521,6 +580,30 @@ SELFTEST_CASES: list[tuple[str, dict[str, str], int]] = [
         0,
     ),
     (
+        "a URL inside a string does not hide later code on that line",
+        {
+            "api/route.ts": 'send({ type: "GO" });',
+            "hooks/use.ts": 'const u = "https://agent.tinyfish.ai/run-sse"; if (event.type === "GO") { go(); }',
+        },
+        0,
+    ),
+    (
+        "a block-comment opener inside a string does not blank real code",
+        {
+            "api/route.ts": 'const s = "/* not a comment"; send({ type: "GO" });',
+            "hooks/use.ts": 'if (event.type === "GO") { go(); }',
+        },
+        0,
+    ),
+    (
+        "a real comment still cannot fake a producer",
+        {
+            "api/route.ts": '// send({ type: "GHOST" });',
+            "hooks/use.ts": 'if (event.type === "GHOST") { go(); }',
+        },
+        1,
+    ),
+    (
         "camelCase field on a non-event receiver is left alone",
         {
             "cli/scout.mjs": (
@@ -598,7 +681,14 @@ def main() -> int:
     elif args.all:
         targets = all_recipes()
     else:
-        targets, touched = changed_recipes(args.base)
+        targets, touched, git_ok = changed_recipes(args.base)
+        if not git_ok:
+            print(
+                f"Could not diff against {args.base!r}: git failed. "
+                "Refusing to report success without checking anything.",
+                file=sys.stderr,
+            )
+            return 2
         if not targets:
             print("No recipe changes to check.")
             return 0

--- a/.github/scripts/check_recipes.py
+++ b/.github/scripts/check_recipes.py
@@ -1,0 +1,642 @@
+#!/usr/bin/env python3
+"""Conformance checks for TinyFish cookbook recipes.
+
+Each recipe relays TinyFish agent events through three hops:
+
+    TinyFish SSE event  ->  the recipe's own /api route  ->  client hook state
+
+Every recipe hand-rolls that relay and picks its own key names along the way,
+so a rename on one hop silently strips a feature on another. The failure is
+invisible: the app builds, the page loads, and the live browser preview simply
+never appears. See issue #86.
+
+This script catches that drift, plus the documentation rules CONTRIBUTING.md
+already asks for. It reads only the recipes a pull request touched, so it stays
+fast and never fails a PR over a file its author did not open.
+
+Structure follows openai/openai-cookbook's .github/scripts/check_notebooks.py:
+diff against the base ref, validate per file, count errors, exit non-zero.
+
+Usage:
+    python .github/scripts/check_recipes.py                 # PR-touched recipes
+    python .github/scripts/check_recipes.py --all           # every recipe
+    python .github/scripts/check_recipes.py --base upstream/main
+    python .github/scripts/check_recipes.py tinyskills       # named recipes
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# Directories at the repo root that are not recipes.
+NOT_RECIPES = {
+    ".git", ".github", ".claude-plugin", "graphify-out",
+    "scripts", "skills", "plugins", "N8N_WorkFlows",
+}
+
+# Recipe collections: containers whose children are the actual recipes.
+RECIPE_COLLECTIONS = {"AABW_Vietnam_Hackathon_Samples"}
+
+SOURCE_SUFFIXES = {".ts", ".tsx", ".js", ".jsx", ".mjs"}
+
+SKIP_DIR_NAMES = {"node_modules", ".next", "dist", "build", "out", "coverage", ".turbo"}
+
+# Event types the TinyFish stream itself emits, so a recipe may consume them
+# without emitting them. Source: docs.tinyfish.ai/key-concepts/endpoints
+# (STARTED, STREAMING_URL, PROGRESS, HEARTBEAT, COMPLETE) plus the terminal
+# run statuses recipes commonly switch on.
+TINYFISH_EVENT_TYPES = {
+    "STARTED", "STREAMING_URL", "PROGRESS", "HEARTBEAT", "COMPLETE",
+    "COMPLETED", "FAILED", "ERROR", "CANCELLED", "TIMEOUT", "RUNNING",
+}
+
+# Markers that a file talks to TinyFish directly, so its event objects are
+# TinyFish's rather than the recipe's own.
+SDK_MARKERS = (
+    "@tiny-fish/sdk", "agent.tinyfish.ai", "run-sse",
+    "from 'tinyfish", 'from "tinyfish',
+)
+
+# camelCase reads of fields the TinyFish stream publishes in snake_case.
+# `receiver_required` fields also appear as ordinary domain properties, so they
+# are only reported when read off a conventional stream-loop variable.
+SDK_FIELDS = (
+    # (wrong, right, receiver_required)
+    ("streamingUrl", "streaming_url", False),
+    ("resultJson", "result", False),
+    ("runId", "run_id", True),
+)
+
+# Conventional names for the event object inside a TinyFish stream loop.
+EVENT_RECEIVERS = {"event", "rawEvent", "evt", "ev", "streamEvent", "sseEvent", "chunk"}
+
+# Other providers' streams also carry a `.type`, with vocabularies this script
+# knows nothing about -- the Vercel AI SDK's `tool-call` / `text-delta` parts,
+# for instance. A file consuming one of those is skipped for reachability
+# rather than guessed at.
+FOREIGN_STREAM_IMPORTS = re.compile(
+    r"""from\s+["'](?:ai|openai|@ai-sdk/[\w-]+|@anthropic-ai/[\w-]+|"""
+    r"""@google/generative-ai|@langchain/[\w-]+|langchain)["']"""
+)
+
+# Sections CONTRIBUTING.md requires in every recipe README.
+README_REQUIREMENTS = [
+    ("live link", re.compile(r"live\s*(link|demo|url|site)|https?://\S+\.(vercel\.app|app|dev|com)", re.I)),
+    ("demo video or gif", re.compile(r"\.gif\b|\.mp4\b|\bdemo\s*(video|gif)\b|youtube\.com|youtu\.be|loom\.com", re.I)),
+    ("TinyFish API snippet", re.compile(r"```[\s\S]*?(tinyfish|TinyFish|agent\.(run|stream))[\s\S]*?```")),
+    ("how to run", re.compile(r"\b(how to run|getting started|quick ?start|installation|setup)\b", re.I)),
+    ("environment variables", re.compile(r"[A-Z][A-Z0-9_]{3,}_(API_)?KEY|\.env", re.I)),
+    ("architecture diagram", re.compile(r"\b(architecture|diagram|flow)\b", re.I)),
+]
+
+# type: "foo" / type: 'foo' in an object literal being built.
+EMITTED_TYPE = re.compile(r"""\btype\s*:\s*["']([A-Za-z0-9_.-]+)["']""")
+
+# Receivers whose `.type` plausibly holds a streamed event's discriminator.
+# Anything else -- `source.type`, `log.type`, `field.type` -- is a domain
+# property with its own vocabulary and is left alone.
+EVENT_LIKE_RECEIVERS = EVENT_RECEIVERS | {
+    "data", "parsed", "payload", "msg", "message", "json", "frame", "update",
+}
+
+# receiver.type === "foo", and the reversed form.
+COMPARED_TYPE = re.compile(
+    r"""\b(\w+)\s*\??\.\s*type\s*(?:===?|!==?)\s*["']([A-Za-z0-9_.-]+)["']"""
+    r"""|["']([A-Za-z0-9_.-]+)["']\s*(?:===?|!==?)\s*\b(\w+)\s*\??\.\s*type\b"""
+)
+
+SWITCH_SUBJECT = re.compile(r"\bswitch\s*\(")
+SWITCH_RECEIVER = re.compile(r"\b(\w+)\s*\??\.\s*type\b")
+CASE_LABEL = re.compile(r"""\bcase\s+["']([A-Za-z0-9_.-]+)["']\s*:""")
+
+ENV_READ = re.compile(
+    r"""process\.env\.([A-Z][A-Z0-9_]*)|process\.env\[["']([A-Z][A-Z0-9_]*)["']\]"""
+)
+
+# Env vars the hosting platform injects; never expected in .env.example.
+ENV_IGNORE_EXACT = {"NODE_ENV", "PORT", "CI", "NEXT_RUNTIME", "ANALYZE"}
+ENV_IGNORE_PREFIXES = ("VERCEL", "GITHUB_", "NEXT_PUBLIC_VERCEL", "AWS_LAMBDA", "NETLIFY")
+
+
+class Problem:
+    """A single finding. `hard` failures set the exit code; warnings do not."""
+
+    def __init__(self, location: str, message: str, hard: bool = True) -> None:
+        self.location = location
+        self.message = message
+        self.hard = hard
+
+    def render(self) -> str:
+        tag = "error" if self.hard else "warn "
+        return f"  [{tag}] {self.location}: {self.message}"
+
+
+def run_git(*args: str) -> str:
+    result = subprocess.run(
+        ["git", *args], cwd=REPO_ROOT, capture_output=True, text=True, check=False
+    )
+    return result.stdout if result.returncode == 0 else ""
+
+
+def all_recipes() -> list[Path]:
+    """Every recipe directory, flattening the hackathon-style collections."""
+    found: list[Path] = []
+    for entry in sorted(REPO_ROOT.iterdir()):
+        if not entry.is_dir() or entry.name.startswith(".") or entry.name in NOT_RECIPES:
+            continue
+        if entry.name in RECIPE_COLLECTIONS:
+            found.extend(
+                child for child in sorted(entry.iterdir())
+                if child.is_dir() and not child.name.startswith(".")
+            )
+        else:
+            found.append(entry)
+    return found
+
+
+def recipe_for(path: Path) -> Path | None:
+    """Map a repo-relative file path to the recipe directory that owns it."""
+    parts = path.parts
+    if not parts or parts[0] in NOT_RECIPES or parts[0].startswith("."):
+        return None
+    if parts[0] in RECIPE_COLLECTIONS:
+        return REPO_ROOT / parts[0] / parts[1] if len(parts) > 1 else None
+    return REPO_ROOT / parts[0]
+
+
+def changed_recipes(base: str) -> tuple[list[Path], set[Path]]:
+    """Recipes touched since `base`, and the exact files that changed."""
+    diff = run_git("diff", "--name-only", base)
+    if not diff:
+        merge_base = run_git("merge-base", "HEAD", base).strip()
+        if merge_base:
+            diff = run_git("diff", "--name-only", merge_base)
+
+    recipes: dict[Path, None] = {}
+    files: set[Path] = set()
+    for line in diff.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        rel = Path(line)
+        files.add(REPO_ROOT / rel)
+        owner = recipe_for(rel)
+        if owner is not None and owner.is_dir():
+            recipes[owner] = None
+    return list(recipes), files
+
+
+def source_files(recipe: Path) -> list[Path]:
+    out: list[Path] = []
+    for path in recipe.rglob("*"):
+        if not path.is_file() or path.suffix not in SOURCE_SUFFIXES:
+            continue
+        if SKIP_DIR_NAMES & set(path.parts):
+            continue
+        out.append(path)
+    return out
+
+
+def show(path: Path) -> str:
+    try:
+        return str(path.relative_to(REPO_ROOT)).replace("\\", "/")
+    except ValueError:
+        return str(path)
+
+
+def read(path: Path) -> str:
+    try:
+        return path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return ""
+
+
+def strip_noise(text: str) -> str:
+    """Blank out comments so they cannot fake a match.
+
+    Block comments are replaced by their own newlines rather than removed, so
+    every reported line number still matches the file on disk.
+    """
+    text = re.sub(r"/\*[\s\S]*?\*/", lambda m: "\n" * m.group(0).count("\n"), text)
+    text = re.sub(r"(?m)//.*$", "", text)
+    return text
+
+
+def line_of(text: str, index: int) -> int:
+    return text.count("\n", 0, index) + 1
+
+
+def balanced_subject(text: str, open_paren: int) -> str:
+    """Return the text inside the parentheses starting at `open_paren`."""
+    depth = 0
+    for i in range(open_paren, min(len(text), open_paren + 500)):
+        if text[i] == "(":
+            depth += 1
+        elif text[i] == ")":
+            depth -= 1
+            if depth == 0:
+                return text[open_paren + 1:i]
+    return ""
+
+
+def enclosing_statement(body: str, index: int) -> str:
+    """The statement containing `index`, bounded by the nearest separators.
+
+    Used to spot a deliberate fallback chain such as
+    `event.streaming_url ?? event.streamingUrl`, which spans lines but reads
+    the documented field first and is therefore correct.
+    """
+    # Only `;` bounds a statement here. Braces are unreliable in TypeScript,
+    # where an inline generic such as `Extract<E, { type: 'X' }>` sits in the
+    # middle of the very expression being examined.
+    start = max(body.rfind(";", 0, index), index - 400, -1)
+    semicolon = body.find(";", index)
+    end = min(semicolon if semicolon != -1 else len(body), index + 200)
+    return body[start + 1:end]
+
+
+def consumed_event_types(body: str) -> list[tuple[str, int]]:
+    """Event-type literals this file compares against, with line numbers.
+
+    `case` labels only count when the enclosing switch is on a `.type`, which
+    keeps ordinary switches (CLI verbs, severity levels, icon names) out.
+    """
+    found: list[tuple[str, int]] = []
+
+    for match in COMPARED_TYPE.finditer(body):
+        receiver = match.group(1) or match.group(4)
+        name = match.group(2) or match.group(3)
+        if receiver in EVENT_LIKE_RECEIVERS:
+            found.append((name, line_of(body, match.start())))
+
+    type_switches: list[tuple[int, int]] = []
+    for match in SWITCH_SUBJECT.finditer(body):
+        open_paren = match.end() - 1
+        subject = balanced_subject(body, open_paren)
+        receiver = SWITCH_RECEIVER.search(subject)
+        if receiver and receiver.group(1) in EVENT_LIKE_RECEIVERS:
+            end = body.find("\n}", open_paren)
+            type_switches.append((open_paren, end if end != -1 else len(body)))
+
+    for match in CASE_LABEL.finditer(body):
+        pos = match.start()
+        if any(start < pos < end for start, end in type_switches):
+            found.append((match.group(1), line_of(body, pos)))
+
+    return found
+
+
+def check_event_reachability(recipe: Path, files: list[Path]) -> list[Problem]:
+    """Every event type a client waits on must be emitted somewhere in the recipe.
+
+    Catches the #86 failure shape: a consumer branch that no producer can ever
+    reach, so the feature behind it is dead while the app still builds.
+    """
+    bodies = {path: strip_noise(read(path)) for path in files}
+
+    emitted: set[str] = set()
+    for body in bodies.values():
+        emitted.update(EMITTED_TYPE.findall(body))
+
+    consumptions: list[tuple[Path, str, int]] = []
+    for path, body in bodies.items():
+        # A file reading another provider's stream has its own vocabulary.
+        if FOREIGN_STREAM_IMPORTS.search(body):
+            continue
+        for name, line_no in consumed_event_types(body):
+            consumptions.append((path, name, line_no))
+
+    def quoted_count(name: str) -> int:
+        return sum(
+            body.count(f'"{name}"') + body.count(f"'{name}'")
+            for body in bodies.values()
+        )
+
+    # Every comparison site holds one quoted copy of the literal. Any surplus
+    # copy is a mention somewhere else -- a union type, an enum table, a
+    # constant -- and counts as evidence the type is real and reachable.
+    compared_count: dict[str, int] = {}
+    for _, name, _ in consumptions:
+        compared_count[name] = compared_count.get(name, 0) + 1
+
+    problems: list[Problem] = []
+    reported: set[tuple[Path, str]] = set()
+    for path, name, line_no in consumptions:
+        if (path, name) in reported or name in emitted or name in TINYFISH_EVENT_TYPES:
+            continue
+        if quoted_count(name) > compared_count[name]:
+            continue
+        reported.add((path, name))
+        problems.append(Problem(
+            f"{show(path)}:{line_no}",
+            f'handles event type "{name}", which no producer in this recipe '
+            f"emits and TinyFish does not send",
+        ))
+    return problems
+
+
+def check_sdk_field_names(recipe: Path, files: list[Path]) -> list[Problem]:
+    """Flag camelCase reads of TinyFish's snake_case event fields.
+
+    Only files that talk to TinyFish directly are scanned; a recipe's own
+    internal SSE payload is free to use camelCase, and most do.
+    """
+    problems: list[Problem] = []
+    for path in files:
+        raw = read(path)
+        if not any(marker in raw for marker in SDK_MARKERS):
+            continue
+        body = strip_noise(raw)
+        for wrong, right, receiver_required in SDK_FIELDS:
+            if receiver_required:
+                receivers = "|".join(sorted(EVENT_RECEIVERS))
+                pattern = re.compile(rf"\b(?:{receivers})\s*(?:\?\.|\.)\s*{wrong}\b")
+            else:
+                # A read (`event.streamingUrl`), never an object key
+                # (`streamingUrl: event.streaming_url`), which is correct.
+                pattern = re.compile(rf"(?:\?\.|\.)\s*{wrong}\b")
+            correct_read = re.compile(rf"(?:\?\.|\.)\s*{right}\b")
+            for match in pattern.finditer(body):
+                # A fallback chain that reads the documented field first is fine.
+                if correct_read.search(enclosing_statement(body, match.start())):
+                    continue
+                problems.append(Problem(
+                    f"{show(path)}:{line_of(body, match.start())}",
+                    f"reads .{wrong} on a TinyFish event; the stream publishes "
+                    f".{right}, so this is always undefined",
+                ))
+    return problems
+
+
+def check_readme(recipe: Path, *, hard: bool) -> list[Problem]:
+    """The README sections CONTRIBUTING.md requires of every project."""
+    readme = next(
+        (c for c in (recipe / "README.md", recipe / "readme.md", recipe / "Readme.md") if c.is_file()),
+        None,
+    )
+    if readme is None:
+        return [Problem(show(recipe), "no README.md (CONTRIBUTING.md requires one)", hard=hard)]
+
+    body = read(readme)
+    missing = [label for label, pattern in README_REQUIREMENTS if not pattern.search(body)]
+    if not missing:
+        return []
+    return [Problem(
+        show(readme),
+        "missing required section(s): " + ", ".join(missing),
+        hard=hard,
+    )]
+
+
+def check_env_documented(recipe: Path, files: list[Path]) -> list[Problem]:
+    """Warn when code reads an env var no example file documents."""
+    examples = [
+        p for p in recipe.rglob(".env*")
+        if p.is_file() and not (SKIP_DIR_NAMES & set(p.parts))
+    ]
+    documented = " ".join(read(p) for p in examples)
+    readme_body = " ".join(read(p) for p in recipe.glob("[Rr]eadme.md"))
+
+    used: set[str] = set()
+    for path in files:
+        for match in ENV_READ.finditer(strip_noise(read(path))):
+            used.add(match.group(1) or match.group(2))
+
+    undocumented = sorted(
+        name for name in used
+        if name not in ENV_IGNORE_EXACT
+        and not name.startswith(ENV_IGNORE_PREFIXES)
+        and name not in documented
+        and name not in readme_body
+    )
+    if not undocumented:
+        return []
+    return [Problem(
+        show(recipe),
+        "env var(s) read in code but not in .env.example or README: "
+        + ", ".join(undocumented),
+        hard=False,
+    )]
+
+
+def check_recipe(recipe: Path, *, readme_hard: bool | None) -> list[Problem]:
+    """`readme_hard` None skips the README check entirely."""
+    files = source_files(recipe)
+    problems = check_event_reachability(recipe, files)
+    problems += check_sdk_field_names(recipe, files)
+    if readme_hard is not None:
+        problems += check_readme(recipe, hard=readme_hard)
+    problems += check_env_documented(recipe, files)
+    return problems
+
+
+SELFTEST_CASES: list[tuple[str, dict[str, str], int]] = [
+    (
+        "consumed event type that nothing emits is reported",
+        {
+            "api/route.ts": 'send({ type: "source_start" });',
+            "hooks/use.ts": 'if (event.type === "source_streaming") { show(); }',
+        },
+        1,
+    ),
+    (
+        "consumed event type that a producer emits is accepted",
+        {
+            "api/route.ts": 'send({ type: "source_streaming" });',
+            "hooks/use.ts": 'if (event.type === "source_streaming") { show(); }',
+        },
+        0,
+    ),
+    (
+        "TinyFish's own event types need no local producer",
+        {"hooks/use.ts": 'if (event.type === "STREAMING_URL") { show(); }'},
+        0,
+    ),
+    (
+        "switch on a non-event .type is not an event switch",
+        {
+            "cli/scout.mjs": (
+                "switch (source.type) {\n"
+                '  case "custom_discovery": return 1;\n'
+                "}\n"
+            )
+        },
+        0,
+    ),
+    (
+        "a union type declaration counts as evidence the type is real",
+        {
+            "ui/log.tsx": (
+                "type Log = { type: 'info' | 'browser' };\n"
+                "const icon = log.type === 'browser' ? a : b;\n"
+            )
+        },
+        0,
+    ),
+    (
+        "another provider's stream vocabulary is left alone",
+        {
+            "api/agent.ts": (
+                'import { streamText } from "ai";\n'
+                'if (part.type === "tool-call") { track(); }\n'
+            )
+        },
+        0,
+    ),
+    (
+        "camelCase read of a TinyFish field is reported",
+        {
+            "api/route.ts": (
+                'import { TinyFish } from "@tiny-fish/sdk";\n'
+                "if (event.streamingUrl) { use(event.streamingUrl); }\n"
+            )
+        },
+        2,
+    ),
+    (
+        "re-emitting under a camelCase key is correct, not a finding",
+        {
+            "api/route.ts": (
+                'import { TinyFish } from "@tiny-fish/sdk";\n'
+                'send({ type: "STREAMING_URL", streamingUrl: event.streaming_url });\n'
+            )
+        },
+        0,
+    ),
+    (
+        "a fallback chain reading the documented field first is accepted",
+        {
+            "api/route.ts": (
+                'import { TinyFish } from "@tiny-fish/sdk";\n'
+                "const url = event.streaming_url ??\n"
+                "    (event as Extract<E, { type: 'STREAMING_URL' }>).streamingUrl;\n"
+            )
+        },
+        0,
+    ),
+    (
+        "camelCase field on a non-event receiver is left alone",
+        {
+            "cli/scout.mjs": (
+                'import { TinyFish } from "@tiny-fish/sdk";\n'
+                "console.log(run.runId);\n"
+            )
+        },
+        0,
+    ),
+]
+
+
+def selftest() -> int:
+    """Exercise the checks against synthetic recipes, guards included."""
+    import tempfile
+
+    failures = 0
+    for name, files, expected in SELFTEST_CASES:
+        with tempfile.TemporaryDirectory() as tmp:
+            recipe = Path(tmp) / "fixture"
+            for rel, content in files.items():
+                target = recipe / rel
+                target.parent.mkdir(parents=True, exist_ok=True)
+                target.write_text(content, encoding="utf-8")
+
+            sources = source_files(recipe)
+            found = check_event_reachability(recipe, sources)
+            found += check_sdk_field_names(recipe, sources)
+
+            if len(found) == expected:
+                print(f"  ok    {name}")
+            else:
+                failures += 1
+                print(f"  FAIL  {name}: expected {expected} finding(s), got {len(found)}")
+                for problem in found:
+                    print(f"          {problem.message}")
+
+    print()
+    if failures:
+        print(f"{failures} of {len(SELFTEST_CASES)} self-test case(s) failed.")
+        return 1
+    print(f"All {len(SELFTEST_CASES)} self-test case(s) passed.")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument("recipes", nargs="*", help="recipe names to check (default: PR-touched)")
+    parser.add_argument("--all", action="store_true", help="check every recipe")
+    parser.add_argument("--base", default="origin/main", help="base ref for the diff")
+    parser.add_argument(
+        "--warn-only", action="store_true", help="report findings but always exit 0"
+    )
+    parser.add_argument(
+        "--selftest", action="store_true", help="verify the checks against synthetic recipes"
+    )
+    args = parser.parse_args()
+
+    if args.selftest:
+        print("Running self-test...")
+        return selftest()
+
+    touched: set[Path] = set()
+    if args.recipes:
+        by_name = {r.name: r for r in all_recipes()}
+        targets = []
+        for name in args.recipes:
+            key = name.strip("/").replace("\\", "/").split("/")[-1]
+            if key not in by_name:
+                print(f"Unknown recipe: {name}", file=sys.stderr)
+                return 2
+            targets.append(by_name[key])
+    elif args.all:
+        targets = all_recipes()
+    else:
+        targets, touched = changed_recipes(args.base)
+        if not targets:
+            print("No recipe changes to check.")
+            return 0
+
+    # README rules are not applied retroactively. In a pull request they are a
+    # hard failure only for a recipe whose README this change actually touches;
+    # a full sweep reports them as warnings so existing recipes written before
+    # the current template do not read as regressions.
+    def readme_mode(recipe: Path) -> bool | None:
+        if args.recipes or args.all:
+            return False
+        if any(f.parent == recipe and f.name.lower() == "readme.md" for f in touched):
+            return True
+        return None
+
+    print(f"Checking {len(targets)} recipe(s)...")
+    findings: list[Problem] = []
+    for recipe in sorted(targets):
+        problems = check_recipe(recipe, readme_hard=readme_mode(recipe))
+        if problems:
+            print(f"\n{recipe.name}")
+            for problem in problems:
+                print(problem.render())
+            findings.extend(problems)
+
+    hard = [p for p in findings if p.hard]
+    warns = [p for p in findings if not p.hard]
+
+    print()
+    if not findings:
+        print(f"All {len(targets)} recipe(s) passed.")
+        return 0
+
+    print(f"{len(hard)} error(s), {len(warns)} warning(s) across {len(targets)} recipe(s).")
+    if hard and not args.warn_only:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/recipe-conformance.yml
+++ b/.github/workflows/recipe-conformance.yml
@@ -1,0 +1,34 @@
+---
+name: Recipe Conformance
+
+on:  # yamllint disable-line rule:truthy
+  pull_request:
+    branches: [main]
+
+permissions:
+  # Only need to read the diff and the recipe sources
+  contents: read
+
+jobs:
+  check-recipes:
+    name: Check Recipes
+    runs-on: ubuntu-latest
+    # Advisory while the open-PR backlog is worked through, so this reports
+    # findings without blocking a merge. Remove this line to make it a gate.
+    continue-on-error: true
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0  # needed for git diff against the base commit
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: '3.12'
+
+      - name: Check recipes touched by this PR
+        run: >-
+          python .github/scripts/check_recipes.py
+          --base ${{ github.event.pull_request.base.sha }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,6 +50,18 @@ Each project folder **must** include a `README.md` with the following:
 6. **How to Run the codebase** (declare any env vars that may be needed here)
 7. **Architecture Diagram**
 
+## Check Your Recipe Before You Push
+
+There's a small script that checks the things reviewers would otherwise check by hand — the README sections listed above, and whether your TinyFish event handling actually lines up end to end:
+
+```bash
+python .github/scripts/check_recipes.py YOUR-NEW-PROJECT
+```
+
+No dependencies, just Python 3. It runs automatically on your pull request too.
+
+The event check is worth knowing about. Each recipe relays TinyFish events through three hops — the TinyFish stream, your own `/api` route, then the hook that renders progress — and it's easy to emit `streamingUrl` on one hop and read `streaming_url` on the next. Nothing crashes when you get this wrong; the live browser preview just silently never appears. The script catches that, including the snake_case field names the TinyFish stream actually publishes (`streaming_url`, `run_id`, `result`).
+
 ## Submitting Your Project
 
 1. Remember to test your new app thoroughly, and make sure it's has a nice `README.md` as described in the above section

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,7 +58,7 @@ There's a small script that checks the things reviewers would otherwise check by
 python .github/scripts/check_recipes.py YOUR-NEW-PROJECT
 ```
 
-No dependencies, just Python 3. It runs automatically on your pull request too.
+No dependencies, just Python 3. It also runs on your pull request, where it reports findings without blocking the merge — so the local run is the one that saves you a round trip.
 
 The event check is worth knowing about. Each recipe relays TinyFish events through three hops — the TinyFish stream, your own `/api` route, then the hook that renders progress — and it's easy to emit `streamingUrl` on one hop and read `streaming_url` on the next. Nothing crashes when you get this wrong; the live browser preview just silently never appears. The script catches that, including the snake_case field names the TinyFish stream actually publishes (`streaming_url`, `run_id`, `result`).
 


### PR DESCRIPTION
Proposed in #243. Follows up #86.

## What this is

Every recipe relays TinyFish agent events through three hops:

```
TinyFish SSE event  ->  the recipe's own /api route  ->  client hook state
```

Each recipe hand-rolls that relay and picks its own key names on the way through — `streamingUrl`, `streaming_url`, and `data.streamingUrl` are all in the tree today. Rename one hop and the next one silently stops matching. Nothing throws, the build passes, the page loads, and the live browser preview just never appears.

#86 found this in `anime-watch-hub` and predicted other recipes had it too. That review never happened repo-wide, so this adds a check that does it mechanically on every PR.

## What it finds today

Run against all 33 recipes, this reports **5 errors in 3 recipes**. I verified each one by hand before writing the check:

| Recipe | Finding | Effect |
|---|---|---|
| `tinyskills` | `hooks/use-generation.ts:202` handles `source_streaming`; `api/scrape-sources/route.ts` emits `source_start`, `source_step`, `source_error`, `source_complete`, `scrape_complete`, `error`, `scrape_start` — never `source_streaming` | Live preview never renders. Featured recipe with a live demo. |
| `stay-scout-hub` | `src/lib/api/area-search.ts:86` handles `event.type === 'STATUS'`; `api/research-area/route.ts` emits only `CONNECTED`, `SCREENSHOT`, `COMPLETE`, `ERROR` | Progress text never updates. Survived the SDK migration in #223 — the route was moved to `EventType.STREAMING_URL` / `event.streaming_url`, the client handler wasn't. |
| `competitor-analysis` | `api/scrape-pricing/route.ts:369-370` reads `event.streamingUrl` off the raw SDK event; the stream publishes `streaming_url`. Also `:382` compares against `'STEP'`, which TinyFish does not send. | Guard never fires, so `competitor_streaming` is never sent and the preview is dead end-to-end. |

To reproduce:

```bash
python .github/scripts/check_recipes.py --all
```

Fixes for these three go in separate PRs so each can be reviewed and reverted on its own — this PR is just the check.

## The checks

1. **Event-type reachability** (error) — an event type a client compares against must be emitted somewhere in the same recipe, or be one TinyFish itself sends.
2. **SDK boundary field names** (error) — camelCase reads of the documented snake_case fields (`streaming_url`, `run_id`, `result`), in files that talk to TinyFish directly.
3. **README sections** (error) — the seven `CONTRIBUTING.md` already requires.
4. **Undocumented env vars** (warning).

## Precision

A noisy gate is worse than no gate, so the false-positive guards got more work than the checks themselves. Earlier drafts flagged all of these; none survive:

- `competitor-scout-cli`'s `switch (source.type)` CLI verbs and `loan-decision-copilot`'s `switch (clarity)` labels — `case` literals only count when the switch subject is an event-like receiver.
- `worldcup-briefing`'s `part.type === "tool-call"` — that's the Vercel AI SDK's vocabulary, so files importing another provider's stream are skipped rather than guessed at.
- `silicon-signal`'s `event.streaming_url ?? event.streamingUrl` — a fallback chain reading the documented field first is correct.
- `research-sentry`'s `log.type === 'browser'`, declared as a union in the same file — a mention outside the comparison sites counts as evidence the type is real.
- `bestbet`'s `send({ type: "STREAMING_URL", streamingUrl: event.streaming_url })` — re-emitting under a camelCase key is fine; only *reads* are flagged.
- `competitor-scout-cli`'s `run.runId` on its own stored records — fields that double as ordinary domain properties need an event-like receiver.

All ten are locked in as regression cases:

```bash
python .github/scripts/check_recipes.py --selftest
```

## Prior art

Structure is taken from [`openai/openai-cookbook`](https://github.com/openai/openai-cookbook)'s `.github/scripts/check_notebooks.py` and `.github/workflows/validate-notebooks.yaml`: `git diff --name-only` against the base ref, validate per file, count errors, `sys.exit(1)`, SHA-pinned actions. Same shape and footprint — they solved changed-files-only cookbook validation already and there was no reason to invent a different one. This needs no `pip install` step since it's stdlib only.

## Notes for review

- **Advisory, not blocking.** The job is `continue-on-error: true`. Turning it into a hard gate today would fail some of the 43 open PRs, which isn't a fair thing to spring on contributors mid-flight. Deleting that one line makes it a gate whenever you want.
- **README rules are not retroactive.** On a full sweep they're warnings; in a PR they're an error only for a recipe whose README that PR touches. 15 existing recipes are missing a demo gif and this deliberately doesn't treat that as a regression.
- **No `Makefile` change.** `Makefile`, `.yamllint`, `.semgrepignore`, and `golden-images.yaml` are Terraform-managed from `github-control`, so I left them alone. Happy to add a `make check-recipes` target through that repo if you'd like one.
- Workflow passes `yamllint -c .yamllint`. Actions pinned to `actions/checkout@v7.0.1` and `actions/setup-python@v7.0.0` by SHA, matching `vuln-scanner-pr.yml`.

Open questions from #243 still stand — mainly whether you'd rather this gate immediately, and whether check 3 should apply to all touched recipes or new ones only. Easy to adjust either way.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated validation for cookbook recipes, including event flow, SDK field usage, README requirements, and environment-variable documentation.
  * Added pull-request checks that automatically review modified recipes and report findings.

* **Documentation**
  * Added contribution guidance for running recipe validation locally and understanding the checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->