### PR TITLE
Remove dead live-preview path from tinyskills

### DIFF
--- a/tinyskills/app/api/scrape-sources/route.ts
+++ b/tinyskills/app/api/scrape-sources/route.ts
@@ -249,7 +249,6 @@ export async function POST(request: Request) {
           content: p.content,
           wordCount: p.wordCount,
           error: p.error,
-          streamingUrl: p.streamingUrl,
         };
       });
 

--- a/tinyskills/app/page.tsx
+++ b/tinyskills/app/page.tsx
@@ -10,7 +10,6 @@ import {
   Check,
   Copy,
   Download,
-  ExternalLink,
   History,
   Settings as SettingsIcon,
   ChevronRight,
@@ -362,16 +361,6 @@ export default function HomePage() {
                     <p className="text-[10px] text-muted-foreground mt-0.5 ml-5">
                       {item.wordCount.toLocaleString()} words
                     </p>
-                  )}
-                  {item.streamingUrl && item.status === "scraping" && (
-                    <a
-                      href={item.streamingUrl}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="absolute right-2 top-2.5 opacity-0 group-hover:opacity-100 text-muted-foreground hover:text-foreground transition-all"
-                    >
-                      <ExternalLink className="w-3 h-3" />
-                    </a>
                   )}
                 </div>
               ))}

--- a/tinyskills/components/skillforge/source-progress.tsx
+++ b/tinyskills/components/skillforge/source-progress.tsx
@@ -12,13 +12,7 @@ import {
   Check,
   X,
   Clock,
-  ExternalLink,
 } from "lucide-react";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from "@/components/ui/tooltip";
 
 const icons: Record<SourceType, React.ReactNode> = {
   docs: <FileText className="h-4 w-4" />,
@@ -58,7 +52,7 @@ export function SourceProgress({ progress }: SourceProgressProps) {
 }
 
 function SourceProgressCard({ progress }: { progress: ScrapeProgress }) {
-  const { source, status, steps, wordCount, error, streamingUrl } = progress;
+  const { source, status, steps, wordCount, error } = progress;
   const type = source.type;
   const config = SOURCE_CONFIG[type];
 
@@ -102,21 +96,6 @@ function SourceProgressCard({ progress }: { progress: ScrapeProgress }) {
         </div>
 
         <div className="flex items-center gap-1">
-          {streamingUrl && status === "scraping" && (
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <a
-                  href={streamingUrl}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="rounded p-1 text-muted-foreground hover:bg-secondary hover:text-foreground"
-                >
-                  <ExternalLink className="h-3.5 w-3.5" />
-                </a>
-              </TooltipTrigger>
-              <TooltipContent>Watch live</TooltipContent>
-            </Tooltip>
-          )}
           <StatusIcon />
         </div>
       </div>

--- a/tinyskills/hooks/use-generation.ts
+++ b/tinyskills/hooks/use-generation.ts
@@ -199,18 +199,6 @@ export function useGeneration(settings: Settings = DEFAULT_SETTINGS) {
                 }
                 return { ...prev, scrapeProgress: newProgress };
               });
-            } else if (event.type === "source_streaming") {
-              setState((prev) => {
-                const newProgress = new Map(prev.scrapeProgress);
-                const existing = newProgress.get(event.sourceUrl);
-                if (existing) {
-                  newProgress.set(event.sourceUrl, {
-                    ...existing,
-                    streamingUrl: event.streamingUrl,
-                  });
-                }
-                return { ...prev, scrapeProgress: newProgress };
-              });
             } else if (event.type === "source_complete") {
               setState((prev) => {
                 const newProgress = new Map(prev.scrapeProgress);

--- a/tinyskills/types/index.ts
+++ b/tinyskills/types/index.ts
@@ -24,7 +24,6 @@ export interface ScrapeProgress {
   content?: string;
   wordCount?: number;
   error?: string;
-  streamingUrl?: string;
 }
 
 export interface GeneratedSkill {


### PR DESCRIPTION
Refs #86. Found by the conformance check in #244.

## The bug

`hooks/use-generation.ts` had a branch for a `source_streaming` event that nothing sends:

```
emitted by app/api/scrape-sources/route.ts:
  source_start, source_step, source_error, source_complete,
  scrape_complete, error, scrape_start

consumed by hooks/use-generation.ts:
  source_start, source_step, source_streaming, source_complete,
  source_error, scrape_complete, error
                ^^^^^^^^^^^^^^^^ never emitted
```

`grep -rn source_streaming tinyskills/` returns exactly one line — the consumer. So the branch never ran, `ScrapeProgress.streamingUrl` was never assigned, and both UI blocks gated on it were unreachable:

- `app/page.tsx:366` — external-link icon on a scraping row
- `components/skillforge/source-progress.tsx:105` — the "Watch live" tooltip link

## Why removing it is the right fix, not emitting it

This is left over from before the recipe moved to TinyFish **Fetch**. The route now calls `client.fetch.getContents({ urls, format: "markdown" })` — a batch request/response with no browser session, so there is no streaming URL to surface. `grep -rn "agent\.\|\.stream(" tinyskills/` finds nothing; the recipe never touches the Agent endpoint.

Making the "Watch live" link work again would mean moving this recipe back to the Agent endpoint, which is metered where Fetch is free. That's a product decision about the recipe's cost profile, not a bug fix, so it isn't mine to make in this PR. Removing the vestigial path leaves the recipe honest about what it actually does.

## Changes

- `types/index.ts` — drop `ScrapeProgress.streamingUrl`
- `app/api/scrape-sources/route.ts` — drop the field copy into `finalResults`
- `hooks/use-generation.ts` — drop the `source_streaming` branch
- `app/page.tsx`, `components/skillforge/source-progress.tsx` — drop the two unreachable links
- drop imports orphaned by the above (`ExternalLink`, and `Tooltip*` in `source-progress.tsx`)

Net −47/+1. No behaviour change: every removed path was already unreachable. `components/ui/tooltip.tsx` is left in place as an unused shadcn primitive.

## Verification

```bash
cd tinyskills && npm ci
npx tsc --noEmit        # clean
npx eslint . --ext .ts,.tsx   # clean
```

Note `npm run lint` fails on its own — the script is `next lint`, which Next removed after 14. Unrelated to this change, but worth knowing if you try it.
