### PR TITLE
Fix stay-scout-hub progress text never updating

### DIFF
--- a/stay-scout-hub/src/app/api/research-area/route.ts
+++ b/stay-scout-hub/src/app/api/research-area/route.ts
@@ -128,6 +128,12 @@ RETURN JSON ONLY (no markdown):
             enqueue({ type: "SCREENSHOT", data: { streamingUrl: event.streaming_url } });
           }
 
+          // The client renders this as the current action. Without it, progress
+          // text stays on the initial message for the whole run.
+          if (event.type === EventType.PROGRESS) {
+            enqueue({ type: "STATUS", message: event.purpose });
+          }
+
           if (event.type === EventType.COMPLETE && event.status === RunStatus.COMPLETED) {
             const raw = typeof event.result === "string" ? JSON.parse(event.result) : event.result;
             const analysis = parseResearchResult(raw as Record<string, unknown>, area, city);

--- a/stay-scout-hub/src/lib/api/area-search.ts
+++ b/stay-scout-hub/src/lib/api/area-search.ts
@@ -83,7 +83,7 @@ export function researchArea(
               });
             }
 
-            if (event.type === 'STATUS') {
+            if (event.type === 'CONNECTED' || event.type === 'STATUS') {
               onStatus({
                 areaId: area.id,
                 areaName: area.name,


### PR DESCRIPTION
Refs #86. Found by the conformance check in #244.

## The bug

The research-area SSE relay disagrees with itself about event names:

```
api/research-area/route.ts emits:   CONNECTED, SCREENSHOT, COMPLETE, ERROR
lib/api/area-search.ts reads:       STATUS, COMPLETE, ERROR
                                    + event.data.streamingUrl
```

`STATUS` is the only thing that sets `currentAction`, so `area-search.ts:86` never ran and the progress line stayed empty for the entire run. The live preview and the final analysis both worked, which is why this wasn't obvious — only the running narration was missing.

`CONNECTED` is the mirror problem: the route sends it with a `Starting research on ${area.name}...` message and nothing reads it, so that first message never appeared either.

This came in with the SDK migration in #223. That PR correctly moved the route to `EventType.STREAMING_URL` / `event.streaming_url`, but the client-side handler kept the older vocabulary and nothing checked the two still lined up.

## The fix

The route is the adapter between TinyFish's event vocabulary and this app's, so that's where the translation belongs.

It was consuming the agent stream but only forwarding `STREAMING_URL` and `COMPLETE`, dropping `PROGRESS` — which is the event that carries the running narration. Per the SDK's own types (`@tiny-fish/sdk/dist/agent/types.d.ts:218-220`), `PROGRESS` has a `purpose: string`. So:

```ts
if (event.type === EventType.PROGRESS) {
  enqueue({ type: "STATUS", message: event.purpose });
}
```

and the client now treats `CONNECTED` like `STATUS`, since both carry a `message` meant for the same line.

Two lines of behaviour, no new event names, no change to the live preview or the completion path.

## Verification

```bash
cd stay-scout-hub && npm ci
npx tsc --noEmit    # clean
```

**Heads up, unrelated to this PR:** `npm run lint` fails for this recipe on `main` — it's `eslint .` with `eslint@^9` but no `eslint.config.js`, so ESLint 9 can't find a config at all. I left it alone since it has nothing to do with this fix, but it means this recipe currently has no working lint. Happy to send a separate PR for that if useful.
