### PR TITLE
Fix competitor-analysis live browser preview never appearing

### DIFF
--- a/competitor-analysis/app/api/scrape-pricing/route.ts
+++ b/competitor-analysis/app/api/scrape-pricing/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest } from 'next/server';
 import type { DetailLevel, PricingTier, CompetitorPricing } from '@/types';
-import { TinyFish } from '@tiny-fish/sdk';
+import { TinyFish, EventType, RunStatus } from '@tiny-fish/sdk';
 
 interface Competitor {
   id: string;
@@ -361,14 +361,11 @@ async function scrapePricingPage(
       browser_profile: 'lite',
     });
 
-    for await (const rawEvent of stream) {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const event: any = rawEvent;
-
+    for await (const event of stream) {
       // Capture streaming URL and send update
-      if (event.streamingUrl && !streamingUrl) {
-        streamingUrl = event.streamingUrl;
-        console.log(`[Scrape] ${competitor.name} got streamingUrl:`, streamingUrl);
+      if (event.type === EventType.STREAMING_URL && !streamingUrl) {
+        streamingUrl = event.streaming_url;
+        console.log(`[Scrape] ${competitor.name} got streaming_url:`, streamingUrl);
         await sendEvent({
           type: 'competitor_streaming',
           competitor: competitor.name,
@@ -378,24 +375,26 @@ async function scrapePricingPage(
         });
       }
 
-      // Forward step updates (keep old heuristics)
-      if (event.type === 'STEP' || event.purpose || event.action) {
-        const stepMessage = event.purpose || event.action || event.message || 'Processing...';
+      // Forward step updates
+      if (event.type === EventType.PROGRESS) {
         await sendEvent({
           type: 'competitor_step',
           competitor: competitor.name,
           id: competitor.id,
-          step: stepMessage,
+          step: event.purpose,
           timestamp: Date.now(),
         });
       }
 
-      // Handle completion
-      if (event.type === 'COMPLETE' && event.status === 'COMPLETED') {
-        const rawResult = event.resultJson ?? event.result ?? {};
+      // Handle completion. A failed run arrives as COMPLETE with a non-COMPLETED
+      // status; there is no separate error event.
+      if (event.type === EventType.COMPLETE) {
+        if (event.status !== RunStatus.COMPLETED) {
+          throw new Error(event.error?.message || 'Extraction failed');
+        }
 
         // Transform to new schema
-        const transformedData = transformToNewSchema(rawResult, competitor.name, competitor.url);
+        const transformedData = transformToNewSchema(event.result ?? {}, competitor.name, competitor.url);
 
         finalResult = {
           company: competitor.name,
@@ -413,11 +412,6 @@ async function scrapePricingPage(
           timestamp: Date.now(),
         });
         break;
-      }
-
-      // Handle errors
-      if (event.type === 'ERROR' || event.status === 'FAILED') {
-        throw new Error(event.message || 'Extraction failed');
       }
     }
 


### PR DESCRIPTION
Refs #86. Found by the conformance check in #244.

## The bug

`app/api/scrape-pricing/route.ts` cast every agent event to `any` and then read camelCase fields the stream doesn't publish:

```ts
const event: any = rawEvent;

if (event.streamingUrl && !streamingUrl) {   // always undefined
```

The SDK sends `streaming_url`. So the guard never fired, `competitor_streaming` was never sent, and the live preview iframe stayed empty for every competitor. The client side was correct the whole time — it just never received the event.

Two more stale reads in the same loop, both masked by a fallback:

| Line | Read | Why it didn't crash |
|---|---|---|
| `:382` | `event.type === 'STEP'` | Not an event type the stream sends. Step forwarding worked only because the condition fell through to `\|\| event.purpose`. |
| `:395` | `event.resultJson ?? event.result` | `resultJson` doesn't exist; completion worked via the `event.result` fallback beside it. |

The `any` cast is what let all three through — with the real event union, each would have been a type error.

## The fix

Dropped the cast and switched the loop to the SDK's own constants, matching how the already-migrated recipes read the stream. From `@tiny-fish/sdk/dist/agent/types.d.ts`:

- `STREAMING_URL` → `streaming_url` (`:212`)
- `PROGRESS` → `purpose` (`:218-220`)
- `COMPLETE` → `status`, `result`, `error` (`:236-253`)
- `EventType` is `STARTED | STREAMING_URL | PROGRESS | HEARTBEAT | COMPLETE` (`:186`) — **there is no `ERROR` event**

That last point matters: the old code had `if (event.type === 'ERROR' || event.status === 'FAILED')`. A failed run actually arrives as `COMPLETE` with a non-`COMPLETED` status and an `error.message`, so error handling now lives inside the `COMPLETE` branch and reads `event.error?.message` — the same `error?.message` idiom already used in `fareguard` and `founder-mode`.

Net −21/+15, and one `eslint-disable-next-line @typescript-eslint/no-explicit-any` goes away.

## Scope

The recipe's own SSE vocabulary is unchanged — the route still emits `competitor_streaming` with a `streamingUrl` key and `competitor_step` with a `step` key, which is exactly what `app/analysis/page.tsx` and `app/dashboard/page.tsx` already read. No client changes needed; fixing the route restores the chain end to end.

Behaviour is otherwise identical. The old step-forwarding condition never fired for `STARTED`, `HEARTBEAT` or `STREAMING_URL` either, since none of them carry a `purpose`.

## Verification

```bash
cd competitor-analysis && npm ci
npx tsc --noEmit    # clean
npm run lint        # clean
```
