### PR TITLE
Make npm run lint work in stay-scout-hub

### DIFF
--- a/stay-scout-hub/eslint.config.mjs
+++ b/stay-scout-hub/eslint.config.mjs
@@ -1,0 +1,16 @@
+import { dirname } from "path";
+import { fileURLToPath } from "url";
+import { FlatCompat } from "@eslint/eslintrc";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const compat = new FlatCompat({
+  baseDirectory: __dirname,
+});
+
+const eslintConfig = [
+  ...compat.extends("next/core-web-vitals", "next/typescript"),
+];
+
+export default eslintConfig;

--- a/stay-scout-hub/package-lock.json
+++ b/stay-scout-hub/package-lock.json
@@ -25,6 +25,7 @@
         "zod": "^3.25.76"
       },
       "devDependencies": {
+        "@eslint/eslintrc": "^3.3.6",
         "@types/node": "^22",
         "@types/react": "^18",
         "@types/react-dom": "^18",
@@ -167,9 +168,9 @@
       }
     },
     "node_modules/@eslint/eslintrc": {
-      "version": "3.3.5",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.5.tgz",
-      "integrity": "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==",
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.6.tgz",
+      "integrity": "sha512-l2Ul9PrHsPCKcEY/ac7VgFj9D80C7S68sOKc618SyHDPK36s1XcFebXY0iTzUVn4Yq+YbwvSnDmCz9yxjX+QrA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -179,7 +180,7 @@
         "globals": "^14.0.0",
         "ignore": "^5.2.0",
         "import-fresh": "^3.2.1",
-        "js-yaml": "^4.1.1",
+        "js-yaml": "^4.3.0",
         "minimatch": "^3.1.5",
         "strip-json-comments": "^3.1.1"
       },
@@ -4775,9 +4776,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {

--- a/stay-scout-hub/package.json
+++ b/stay-scout-hub/package.json
@@ -26,6 +26,7 @@
     "@google/generative-ai": "latest"
   },
   "devDependencies": {
+    "@eslint/eslintrc": "^3.3.6",
     "@types/node": "^22",
     "@types/react": "^18",
     "@types/react-dom": "^18",

--- a/stay-scout-hub/src/app/api/discover-areas/route.ts
+++ b/stay-scout-hub/src/app/api/discover-areas/route.ts
@@ -17,7 +17,7 @@ function getPurposeDescription(purpose: string, customPurpose?: string): string 
   return purposes[purpose] || "General travel";
 }
 
-function generateFallbackAreas(city: string, purpose: string) {
+function generateFallbackAreas(city: string) {
   return [
     { id: "city-center", name: `${city} City Center`, type: "neighborhood", description: "The central business and commercial district", whyRecommended: "Central location with easy access to transport, restaurants, and main attractions", keyLocations: ["Main Train Station", "Central Business District"] },
     { id: "near-airport", name: `${city} Airport Area`, type: "area", description: "Hotels near the main airport", whyRecommended: "Convenient for early flights or late arrivals, shuttle services available", keyLocations: ["International Airport", "Airport Express"] },
@@ -52,7 +52,7 @@ export async function POST(request: Request) {
       .slice(0, 4);
 
     if (!urls.length) {
-      return Response.json({ areas: generateFallbackAreas(city, purpose) });
+      return Response.json({ areas: generateFallbackAreas(city) });
     }
 
     // Step 2 — Fetch content from the travel guides
@@ -64,7 +64,7 @@ export async function POST(request: Request) {
       .slice(0, 6000);
 
     if (!pagesContent) {
-      return Response.json({ areas: generateFallbackAreas(city, purpose) });
+      return Response.json({ areas: generateFallbackAreas(city) });
     }
 
     // Step 3 — Gemini extracts structured neighborhood recommendations
@@ -103,11 +103,11 @@ Return ONLY valid JSON — no markdown, no code blocks:
       if (jsonMatch) areas = JSON.parse(jsonMatch[0]);
       else throw new Error("No JSON array found");
     } catch {
-      areas = generateFallbackAreas(city, purpose);
+      areas = generateFallbackAreas(city);
     }
 
     return Response.json({ areas });
   } catch {
-    return Response.json({ areas: generateFallbackAreas(city, purpose) });
+    return Response.json({ areas: generateFallbackAreas(city) });
   }
 }

--- a/stay-scout-hub/src/components/AreaCard.tsx
+++ b/stay-scout-hub/src/components/AreaCard.tsx
@@ -168,7 +168,7 @@ export function AreaCard({ result }: AreaCardProps) {
                         <span className="text-muted-foreground">Reviews mention:</span>
                         <ul className="mt-1 list-disc list-inside text-muted-foreground">
                           {result.analysis.reviewHighlights.map((h, i) => (
-                            <li key={i}>"{h}"</li>
+                            <li key={i}>&quot;{h}&quot;</li>
                           ))}
                         </ul>
                       </div>

--- a/stay-scout-hub/src/components/SearchFormV2.tsx
+++ b/stay-scout-hub/src/components/SearchFormV2.tsx
@@ -76,7 +76,7 @@ export function SearchFormV2({ onSearch, isSearching }: SearchFormV2Props) {
       >
         <label className="text-sm font-medium text-muted-foreground flex items-center gap-2 mb-4">
           <Sparkles className="w-4 h-4 text-primary" />
-          What's the purpose of your stay?
+          What&apos;s the purpose of your stay?
         </label>
         
         <PurposeSelector

--- a/stay-scout-hub/src/components/ui/input.tsx
+++ b/stay-scout-hub/src/components/ui/input.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { cn } from "@/lib/utils";
 
-export interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {}
+export type InputProps = React.InputHTMLAttributes<HTMLInputElement>;
 
 const Input = React.forwardRef<HTMLInputElement, InputProps>(
   ({ className, type, ...props }, ref) => {

--- a/stay-scout-hub/src/components/ui/textarea.tsx
+++ b/stay-scout-hub/src/components/ui/textarea.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { cn } from "@/lib/utils";
 
-export interface TextareaProps extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+export type TextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement>;
 
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
   ({ className, ...props }, ref) => {

--- a/stay-scout-hub/src/hooks/useAreaSearch.ts
+++ b/stay-scout-hub/src/hooks/useAreaSearch.ts
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState, useCallback, useRef } from 'react';
-import { AreaSuggestion, AreaResearchResult, SearchParams } from '@/types/hotel';
+import { AreaResearchResult, SearchParams } from '@/types/hotel';
 import { discoverAreas, researchArea } from '@/lib/api/area-search';
 
 export function useAreaSearch() {

--- a/stay-scout-hub/tailwind.config.ts
+++ b/stay-scout-hub/tailwind.config.ts
@@ -1,4 +1,5 @@
 import type { Config } from "tailwindcss";
+import tailwindcssAnimate from "tailwindcss-animate";
 
 const config: Config = {
   content: ["./src/**/*.{ts,tsx}"],
@@ -33,7 +34,7 @@ const config: Config = {
       },
     },
   },
-  plugins: [require("tailwindcss-animate")],
+  plugins: [tailwindcssAnimate],
 };
 
 export default config;


### PR DESCRIPTION
First of the recipes in #248. Independent of #246, which touches different files in this recipe.

## The bug

```bash
cd stay-scout-hub && npm ci && npm run lint
# > eslint .
# From ESLint v9.0.0, the default configuration file is now eslint.config.js.
# exit 2
```

The script is `eslint .` with `eslint@^9` and no `eslint.config.*` anywhere in the recipe. ESLint 9 only reads flat config, so it exits before linting a single file. This recipe has never had working lint.

## Why `FlatCompat` and not the style the other recipes use

The 10 recipes that already have `eslint.config.mjs` are all on Next 16 and import the flat subpaths:

```js
import nextVitals from "eslint-config-next/core-web-vitals";
```

That can't be copied here. `eslint-config-next@15.3.3` ships those files as **legacy eslintrc objects** —

```js
// node_modules/eslint-config-next/core-web-vitals.js
module.exports = {
  extends: [require.resolve('.'), 'plugin:@next/next/core-web-vitals'],
}
```

— and declares no `exports` subpaths at all, only `"main"`. Spreading that into a flat config array doesn't work.

So this uses `FlatCompat` from `@eslint/eslintrc`, which is exactly what `create-next-app` generated for Next 15, extending the same `next/core-web-vitals` + `next/typescript` pair the Next 16 recipes get. `@eslint/eslintrc` is added as an explicit `devDependency` rather than relying on it being hoisted out of `eslint`'s own dependency tree.

The alternative is upgrading this recipe to Next 16 and using the subpath style. That's a much bigger diff with real behaviour risk, so I raised it as a question on #248 rather than assuming.

## The 8 errors turning lint on surfaced

A config-only change would have left `npm run lint` red, which is worse than failing loudly. All fixed here:

| File | Rule | Fix |
|---|---|---|
| `api/discover-areas/route.ts` | `no-unused-vars` | dropped the unused `purpose` param from `generateFallbackAreas` + its 4 call sites |
| `AreaCard.tsx` ×2 | `react/no-unescaped-entities` | `"` → `&quot;` |
| `SearchFormV2.tsx` | `react/no-unescaped-entities` | `'` → `&apos;` |
| `ui/input.tsx` | `no-empty-object-type` | empty `interface InputProps extends X {}` → `type InputProps = X` |
| `ui/textarea.tsx` | `no-empty-object-type` | same |
| `hooks/useAreaSearch.ts` | `no-unused-vars` | removed unused `AreaSuggestion` import |
| `tailwind.config.ts` | `no-require-imports` | `require("tailwindcss-animate")` → `import` (already a declared dependency) |

All behaviour-preserving. `purpose` is still read elsewhere in that route for `getPurposeDescription`; it was only ever unused inside `generateFallbackAreas`.

## Verification

```bash
cd stay-scout-hub && npm ci
npm run lint      # exit 0
npx tsc --noEmit  # exit 0
```

The `package-lock.json` change is just `@eslint/eslintrc` moving to a direct devDependency (it was already present transitively at 3.3.5) plus a transitive `js-yaml` bump.

## Remaining five

`restaurant-comparison-tool`, `tutor-finder`, `scholarship-finder`, `summer-school-finder`, `tenders-finder` — same shape, three different root causes, all measured in #248. Sending this one first so the approach can be checked before I repeat it five times.
