### PR TITLE
Make npm run lint work in the remaining five recipes

### DIFF
--- a/restaurant-comparison-tool/.eslintrc.json
+++ b/restaurant-comparison-tool/.eslintrc.json
@@ -1,3 +1,0 @@
-{
-  "extends": "next/core-web-vitals"
-}

--- a/restaurant-comparison-tool/eslint.config.mjs
+++ b/restaurant-comparison-tool/eslint.config.mjs
@@ -1,0 +1,16 @@
+import { dirname } from "path";
+import { fileURLToPath } from "url";
+import { FlatCompat } from "@eslint/eslintrc";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const compat = new FlatCompat({
+  baseDirectory: __dirname,
+});
+
+const eslintConfig = [
+  ...compat.extends("next/core-web-vitals"),
+];
+
+export default eslintConfig;

--- a/restaurant-comparison-tool/package-lock.json
+++ b/restaurant-comparison-tool/package-lock.json
@@ -20,6 +20,7 @@
         "tailwind-merge": "^3.4.0"
       },
       "devDependencies": {
+        "@eslint/eslintrc": "^3.3.5",
         "@tailwindcss/postcss": "^4.1.18",
         "@types/node": "^24",
         "@types/react": "^19",

--- a/restaurant-comparison-tool/package.json
+++ b/restaurant-comparison-tool/package.json
@@ -21,6 +21,7 @@
     "tailwind-merge": "^3.4.0"
   },
   "devDependencies": {
+    "@eslint/eslintrc": "^3.3.5",
     "@tailwindcss/postcss": "^4.1.18",
     "@types/node": "^24",
     "@types/react": "^19",

--- a/scholarship-finder/eslint.config.mjs
+++ b/scholarship-finder/eslint.config.mjs
@@ -1,0 +1,16 @@
+import { dirname } from "path";
+import { fileURLToPath } from "url";
+import { FlatCompat } from "@eslint/eslintrc";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const compat = new FlatCompat({
+  baseDirectory: __dirname,
+});
+
+const eslintConfig = [
+  ...compat.extends("next/core-web-vitals", "next/typescript"),
+];
+
+export default eslintConfig;

--- a/scholarship-finder/package-lock.json
+++ b/scholarship-finder/package-lock.json
@@ -21,6 +21,7 @@
         "tailwindcss-animate": "^1.0.7"
       },
       "devDependencies": {
+        "@eslint/eslintrc": "^3.3.5",
         "@types/node": "^22.16.5",
         "@types/react": "^18.3.23",
         "@types/react-dom": "^18.3.7",

--- a/scholarship-finder/package.json
+++ b/scholarship-finder/package.json
@@ -6,7 +6,7 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "eslint"
   },
   "dependencies": {
     "@radix-ui/react-select": "^2.1.6",
@@ -22,6 +22,7 @@
     "@google/generative-ai": "latest"
   },
   "devDependencies": {
+    "@eslint/eslintrc": "^3.3.5",
     "@types/node": "^22.16.5",
     "@types/react": "^18.3.23",
     "@types/react-dom": "^18.3.7",

--- a/scholarship-finder/src/components/CompareDashboard.tsx
+++ b/scholarship-finder/src/components/CompareDashboard.tsx
@@ -73,7 +73,7 @@ export function CompareDashboard({ scholarships, onClose }: CompareDashboardProp
                     )
                   },
                   { label: "Additional Info", icon: null, render: (s: Scholarship) => <span className="text-sm text-muted-foreground">{s.additionalInfo || "N/A"}</span> },
-                ].map(({ label, icon, render }, idx) => (
+                ].map(({ label, icon, render }) => (
                   <tr key={label} className="border-b border-muted">
                     <td className="p-4 font-semibold bg-orange-50 text-orange-900">
                       <div className="flex items-center gap-2">{icon}{label}</div>

--- a/scholarship-finder/src/components/LoadingAnimation.tsx
+++ b/scholarship-finder/src/components/LoadingAnimation.tsx
@@ -67,7 +67,6 @@ export function LoadingAnimation({ searchState }: LoadingAnimationProps) {
             <AgentCard
               key={agent.agentId}
               agent={agent}
-              isExpanded={expandedAgent === agent.agentId}
               onExpand={() => setExpandedAgent(expandedAgent === agent.agentId ? null : agent.agentId)}
             />
           ))}
@@ -137,7 +136,7 @@ export function LoadingAnimation({ searchState }: LoadingAnimationProps) {
   );
 }
 
-function AgentCard({ agent, isExpanded, onExpand }: { agent: AgentStatus; isExpanded: boolean; onExpand: () => void }) {
+function AgentCard({ agent, onExpand }: { agent: AgentStatus; onExpand: () => void }) {
   const statusColors = {
     pending: "border-muted-foreground/30",
     running: "border-primary",

--- a/scholarship-finder/src/components/SearchResults.tsx
+++ b/scholarship-finder/src/components/SearchResults.tsx
@@ -19,7 +19,8 @@ export function SearchResults({ scholarships, searchSummary, searchParams }: Sea
   const handleToggleSelect = (id: string) => {
     setSelectedIds((prev) => {
       const next = new Set(prev);
-      next.has(id) ? next.delete(id) : next.add(id);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
       return next;
     });
   };

--- a/scholarship-finder/src/hooks/useScholarshipSearch.ts
+++ b/scholarship-finder/src/hooks/useScholarshipSearch.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useCallback } from "react";
-import type { Scholarship, SearchParams, SearchResponse, SearchState } from "@/types/scholarship";
+import type { SearchParams, SearchResponse, SearchState } from "@/types/scholarship";
 
 const emptyState = (): SearchState => ({
   step: 0,

--- a/scholarship-finder/tailwind.config.ts
+++ b/scholarship-finder/tailwind.config.ts
@@ -1,4 +1,5 @@
 import type { Config } from "tailwindcss";
+import tailwindcssAnimate from "tailwindcss-animate";
 const config: Config = {
   darkMode: ["class"],
   content: ["./src/**/*.{ts,tsx}"],
@@ -31,6 +32,6 @@ const config: Config = {
       animation: { "fade-in": "fade-in 0.3s ease-out" },
     },
   },
-  plugins: [require("tailwindcss-animate")],
+  plugins: [tailwindcssAnimate],
 };
 export default config;

--- a/summer-school-finder/eslint.config.mjs
+++ b/summer-school-finder/eslint.config.mjs
@@ -1,0 +1,16 @@
+import { dirname } from "path";
+import { fileURLToPath } from "url";
+import { FlatCompat } from "@eslint/eslintrc";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const compat = new FlatCompat({
+  baseDirectory: __dirname,
+});
+
+const eslintConfig = [
+  ...compat.extends("next/core-web-vitals", "next/typescript"),
+];
+
+export default eslintConfig;

--- a/summer-school-finder/package-lock.json
+++ b/summer-school-finder/package-lock.json
@@ -25,6 +25,7 @@
         "tailwindcss-animate": "^1.0.7"
       },
       "devDependencies": {
+        "@eslint/eslintrc": "^3.3.5",
         "@types/node": "^22.16.5",
         "@types/react": "^18.3.23",
         "@types/react-dom": "^18.3.7",

--- a/summer-school-finder/package.json
+++ b/summer-school-finder/package.json
@@ -6,7 +6,7 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "eslint"
   },
   "dependencies": {
     "@radix-ui/react-checkbox": "^1.3.2",
@@ -26,6 +26,7 @@
     "tailwindcss-animate": "^1.0.7"
   },
   "devDependencies": {
+    "@eslint/eslintrc": "^3.3.5",
     "@types/node": "^22.16.5",
     "@types/react": "^18.3.23",
     "@types/react-dom": "^18.3.7",

--- a/summer-school-finder/src/app/page.tsx
+++ b/summer-school-finder/src/app/page.tsx
@@ -54,7 +54,8 @@ export default function Home() {
   const handleSelect = (index: number, selected: boolean) => {
     setSelectedIndices((prev) => {
       const next = new Set(prev);
-      selected ? next.add(index) : next.delete(index);
+      if (selected) next.add(index);
+      else next.delete(index);
       return next;
     });
   };

--- a/summer-school-finder/tailwind.config.ts
+++ b/summer-school-finder/tailwind.config.ts
@@ -1,4 +1,5 @@
 import type { Config } from "tailwindcss";
+import tailwindcssAnimate from "tailwindcss-animate";
 
 const config: Config = {
   darkMode: ["class"],
@@ -63,7 +64,7 @@ const config: Config = {
       },
     },
   },
-  plugins: [require("tailwindcss-animate")],
+  plugins: [tailwindcssAnimate],
 };
 
 export default config;

--- a/tenders-finder/eslint.config.mjs
+++ b/tenders-finder/eslint.config.mjs
@@ -1,0 +1,18 @@
+import { defineConfig, globalIgnores } from "eslint/config";
+import nextVitals from "eslint-config-next/core-web-vitals";
+import nextTs from "eslint-config-next/typescript";
+
+const eslintConfig = defineConfig([
+  ...nextVitals,
+  ...nextTs,
+  // Override default ignores of eslint-config-next.
+  globalIgnores([
+    // Default ignores of eslint-config-next:
+    ".next/**",
+    "out/**",
+    "build/**",
+    "next-env.d.ts",
+  ]),
+]);
+
+export default eslintConfig;

--- a/tenders-finder/package.json
+++ b/tenders-finder/package.json
@@ -6,7 +6,7 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "eslint"
   },
   "dependencies": {
     "@tiny-fish/sdk": "latest",

--- a/tenders-finder/src/components/tender/AgentPreviewCard.tsx
+++ b/tenders-finder/src/components/tender/AgentPreviewCard.tsx
@@ -12,7 +12,11 @@ interface AgentPreviewCardProps {
 
 export function AgentPreviewCard({ agent, onExpandPreview }: AgentPreviewCardProps) {
   const [shouldHide, setShouldHide] = useState(false);
-  const [iframeLoaded, setIframeLoaded] = useState(false);
+  const [loadedUrl, setLoadedUrl] = useState<string | null>(null);
+
+  // Derived rather than reset in an effect, so a new URL shows the placeholder
+  // again without a synchronising render pass.
+  const iframeLoaded = !!agent.streamingUrl && loadedUrl === agent.streamingUrl;
 
   useEffect(() => {
     if (agent.status === "complete" || agent.status === "error") {
@@ -20,10 +24,6 @@ export function AgentPreviewCard({ agent, onExpandPreview }: AgentPreviewCardPro
       return () => clearTimeout(timer);
     }
   }, [agent.status]);
-
-  useEffect(() => {
-    if (agent.streamingUrl) setIframeLoaded(false);
-  }, [agent.streamingUrl]);
 
   if (shouldHide) return null;
 
@@ -102,7 +102,7 @@ export function AgentPreviewCard({ agent, onExpandPreview }: AgentPreviewCardPro
               src={agent.streamingUrl}
               className="w-full h-full border-0"
               title={`Live preview for ${agent.name}`}
-              onLoad={() => setIframeLoaded(true)}
+              onLoad={() => setLoadedUrl(agent.streamingUrl ?? null)}
             />
             {onExpandPreview && iframeLoaded && (
               <button

--- a/tenders-finder/src/components/tender/LiveBrowserModal.tsx
+++ b/tenders-finder/src/components/tender/LiveBrowserModal.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import { X, Monitor, Maximize2, Minimize2, Loader2 } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -13,9 +13,11 @@ interface LiveBrowserModalProps {
 
 export function LiveBrowserModal({ isOpen, streamingUrl, platformName, onClose }: LiveBrowserModalProps) {
   const [isFullscreen, setIsFullscreen] = useState(false);
-  const [isLoading, setIsLoading] = useState(true);
+  const [loadedUrl, setLoadedUrl] = useState<string | null>(null);
 
-  useEffect(() => { setIsLoading(true); }, [streamingUrl]);
+  // Derived rather than reset in an effect, so a new URL shows the spinner again
+  // without a synchronising render pass.
+  const isLoading = loadedUrl !== streamingUrl;
 
   if (!isOpen) return null;
 
@@ -75,7 +77,7 @@ export function LiveBrowserModal({ isOpen, streamingUrl, platformName, onClose }
               src={streamingUrl}
               className="w-full h-full border-0"
               title={`Live preview for ${platformName}`}
-              onLoad={() => setIsLoading(false)}
+              onLoad={() => setLoadedUrl(streamingUrl)}
             />
           </div>
         </motion.div>

--- a/tenders-finder/src/hooks/useTenderSearch.ts
+++ b/tenders-finder/src/hooks/useTenderSearch.ts
@@ -220,7 +220,8 @@ Return ONLY this JSON with no extra text:
   const toggleTenderSelection = useCallback((tenderId: string) => {
     setState((prev) => {
       const newSelected = new Set(prev.selectedTenders);
-      newSelected.has(tenderId) ? newSelected.delete(tenderId) : newSelected.add(tenderId);
+      if (newSelected.has(tenderId)) newSelected.delete(tenderId);
+      else newSelected.add(tenderId);
       return { ...prev, selectedTenders: newSelected };
     });
   }, []);

--- a/tenders-finder/tailwind.config.ts
+++ b/tenders-finder/tailwind.config.ts
@@ -1,4 +1,5 @@
 import type { Config } from "tailwindcss";
+import tailwindcssAnimate from "tailwindcss-animate";
 const config: Config = {
   darkMode: ["class"],
   content: ["./src/**/*.{ts,tsx}"],
@@ -21,6 +22,6 @@ const config: Config = {
       borderRadius: { lg: "var(--radius)", md: "calc(var(--radius) - 2px)", sm: "calc(var(--radius) - 4px)" },
     },
   },
-  plugins: [require("tailwindcss-animate")],
+  plugins: [tailwindcssAnimate],
 };
 export default config;

--- a/tutor-finder/eslint.config.mjs
+++ b/tutor-finder/eslint.config.mjs
@@ -1,0 +1,16 @@
+import { dirname } from "path";
+import { fileURLToPath } from "url";
+import { FlatCompat } from "@eslint/eslintrc";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const compat = new FlatCompat({
+  baseDirectory: __dirname,
+});
+
+const eslintConfig = [
+  ...compat.extends("next/core-web-vitals", "next/typescript"),
+];
+
+export default eslintConfig;

--- a/tutor-finder/package-lock.json
+++ b/tutor-finder/package-lock.json
@@ -23,6 +23,7 @@
         "tailwindcss-animate": "^1.0.7"
       },
       "devDependencies": {
+        "@eslint/eslintrc": "^3.3.5",
         "@types/node": "^22.16.5",
         "@types/react": "^18.3.23",
         "@types/react-dom": "^18.3.7",

--- a/tutor-finder/package.json
+++ b/tutor-finder/package.json
@@ -6,7 +6,7 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "eslint"
   },
   "dependencies": {
     "@radix-ui/react-dialog": "^1.1.14",
@@ -28,6 +28,7 @@
     "tailwindcss-animate": "^1.0.7"
   },
   "devDependencies": {
+    "@eslint/eslintrc": "^3.3.5",
     "@types/node": "^22.16.5",
     "@types/react": "^18.3.23",
     "@types/react-dom": "^18.3.7",

--- a/tutor-finder/src/components/TutorCard.tsx
+++ b/tutor-finder/src/components/TutorCard.tsx
@@ -8,8 +8,7 @@ import {
   TrendingUp, 
   ExternalLink,
   Check,
-  Monitor,
-  BookOpen
+  Monitor
 } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import { cn } from '@/lib/utils';

--- a/tutor-finder/src/hooks/useTutorSearch.ts
+++ b/tutor-finder/src/hooks/useTutorSearch.ts
@@ -21,7 +21,8 @@ export function useTutorSearch() {
   const toggleTutorSelection = (tutorId: string) => {
     setState((prev) => {
       const next = new Set(prev.selectedTutorIds);
-      next.has(tutorId) ? next.delete(tutorId) : next.add(tutorId);
+      if (next.has(tutorId)) next.delete(tutorId);
+      else next.add(tutorId);
       return { ...prev, selectedTutorIds: next };
     });
   };
@@ -152,7 +153,7 @@ export function useTutorSearch() {
                 } catch { /* ignore parse errors */ }
               }
             }
-          } catch (error) {
+          } catch {
             setState((prev) => ({
               ...prev,
               agents: prev.agents.map((a) =>

--- a/tutor-finder/tailwind.config.ts
+++ b/tutor-finder/tailwind.config.ts
@@ -1,4 +1,5 @@
 import type { Config } from "tailwindcss";
+import tailwindcssAnimate from "tailwindcss-animate";
 const config: Config = {
   darkMode: ["class"],
   content: ["./src/**/*.{ts,tsx}"],
@@ -25,6 +26,6 @@ const config: Config = {
       animation: { "fade-in": "fade-in 0.3s ease-out" },
     },
   },
-  plugins: [require("tailwindcss-animate")],
+  plugins: [tailwindcssAnimate],
 };
 export default config;


### PR DESCRIPTION
Completes #248. Same shape as #249, which has the detailed rationale.

## Before

None of these five could lint at all. Measured by installing each and running its own script:

| Recipe | Setup | Result |
|---|---|---|
| `restaurant-comparison-tool` | `eslint .` + `.eslintrc.json` | exit 2 — ESLint 9 ignores `.eslintrc.*` |
| `tutor-finder` | `next lint`, no config | exit 1 — blocks on an interactive setup prompt |
| `scholarship-finder` | `next lint`, no config | exit 1 — same |
| `summer-school-finder` | `next lint`, no config | exit 1 — same |
| `tenders-finder` | `next lint` on Next 16 | exit 1 — `next lint` was removed in Next 16 |

## Two config styles, because they aren't interchangeable

The four on **Next 15** use `FlatCompat`. `eslint-config-next@15` ships `core-web-vitals.js` and `typescript.js` as legacy eslintrc objects (`module.exports = { extends: [...] }`) and declares no `exports` subpaths, so the flat subpath imports used by the Next 16 recipes cannot resolve there.

`tenders-finder` is on Next 16, so it gets the subpath style — byte-identical to the ten recipes that already have a config.

Deliberately **not** standardising strictness: `restaurant-comparison-tool` keeps extending `core-web-vitals` only, exactly as its `.eslintrc.json` did. Making it stricter would have been a separate decision smuggled into a repair. The four with no previous config get `core-web-vitals` + `typescript`, matching the Next 16 recipes.

Scripts move from `next lint` to `eslint`, the idiom in 9 of the 10 already-working recipes.

## The 12 errors turning lint on surfaced

The interesting two are in `tenders-finder`, which is on Next 16 and therefore gets the newer `react-hooks` rules:

```tsx
// before — flagged by react-hooks/set-state-in-effect
const [isLoading, setIsLoading] = useState(true);
useEffect(() => { setIsLoading(true); }, [streamingUrl]);

// after — derived, no effect at all
const [loadedUrl, setLoadedUrl] = useState<string | null>(null);
const isLoading = loadedUrl !== streamingUrl;
// ...
<iframe onLoad={() => setLoadedUrl(streamingUrl)} />
```

Both violations (`LiveBrowserModal.tsx`, `AgentPreviewCard.tsx`) were the same thing: an effect resetting an iframe loading flag when the URL changed. Deriving the flag from *which URL actually loaded* removes the effect entirely and a piece of state with it — which is the answer the rule is pointing at, rather than a suppression comment. A new URL brings the spinner back automatically with no synchronising code.

The rest are mechanical: ternary-as-statement in four recipes, unused vars and imports, and a dead `isExpanded` prop in `scholarship-finder` that was passed but never read (removed from the prop, the type and the call site — all in one file).

`require("tailwindcss-animate")` → `import` in four tailwind configs. There's no in-repo precedent for that ESM import, since the Next 16 recipes are on Tailwind v4 and don't use the plugin, so rather than assume CJS interop works I loaded each config through `jiti` — the loader Tailwind v3 actually uses — and confirmed the animate plugin is present and valid in all four. That also retroactively validates the same change in #249.

## Verification

```bash
for r in restaurant-comparison-tool tutor-finder scholarship-finder summer-school-finder tenders-finder; do
  (cd $r && npm install && npm run lint && npx tsc --noEmit)
done
```

`npm run lint` and `tsc --noEmit` exit **0** in all five.

Two warnings left untouched on purpose: an `exhaustive-deps` warning in `summer-school-finder/src/hooks/useSummerSchoolSearch.ts` — adding `runAgent` to the dependency array risks changing render behaviour, which isn't a call to make inside a lint repair. Nothing outstanding in the other four.

The four `package-lock.json` diffs are **one line each** — `@eslint/eslintrc` added to root `devDependencies`, pinned to `^3.3.5` which the already-locked version satisfies, so no version churn.

## One pre-existing problem I did not fix

`npm ci` already fails in `tutor-finder` on `main`:

```
npm error `npm ci` can only install packages when your package.json and package-lock.json are in sync.
npm error Missing: @radix-ui/react-label@2.1.15 from lock file
npm error Missing: @radix-ui/react-separator@1.1.15 from lock file
npm error Missing: @radix-ui/react-toggle@1.1.18 from lock file
npm error Missing: @radix-ui/react-tooltip@1.2.16 from lock file
```

Its lock predates four declared dependencies. Regenerating it is ~900 lines of unrelated churn that would bury this change, so I left it and used `npm install` to verify that recipe. Filed separately — it deserves its own PR where a lock regeneration is the expected diff.

Happy to split this per-recipe if you'd rather review five smaller PRs.
