### PR TITLE
List the AI Product Idea Generator workflow in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,7 @@ Pre-built n8n workflows using TinyFish — import the JSON and go.
 | [Competitor Scout](./N8N_WorkFlows/Competitor%20Scout%20CLI) | Research competitor feature decisions with OpenAI planning + TinyFish evidence collection |
 | [Web Research Agent](./N8N_WorkFlows/Web%20Research%20Agent) | Chatbot that scrapes any website with TinyFish and saves summaries to Notion |
 | [Daily Product Hunt Tracker](./N8N_WorkFlows/Daily%20Product%20Hunt%20Tracker) | Scheduled workflow delivering daily top 5 trending Product Hunt products to Telegram |
+| [AI Product Idea Generator](./N8N_WorkFlows/ai-competitor-analysis) | Scrapes Reddit pain points and Product Hunt solutions, then uses Gemini to surface unsolved market gaps |
 
 ## Getting Started
 


### PR DESCRIPTION
`N8N_WorkFlows/ai-competitor-analysis` landed in #78 but was never added to the **n8n Workflows** table. It has a full README and a working `ai-competitor-radar.json`, but nothing in the repo links to it, so it's effectively invisible to anyone browsing.

One row added. All four directories under `N8N_WorkFlows/` are now listed.

```bash
# before: 3 of 4 listed
ls -d N8N_WorkFlows/*/
```

**On the naming:** I used the title from the workflow's own README ("AI Product Idea Generator") rather than the folder name. The folder is `ai-competitor-analysis` and the JSON is `ai-competitor-radar.json`, but the workflow itself scrapes Reddit pain points and Product Hunt listings to surface unsolved market gaps — the folder name looks like a leftover from an earlier version of the idea.

I deliberately did **not** rename the folder. That would turn a one-line docs fix into a rename plus link updates, and the folder name is your call, not mine. Happy to send that separately if you want the naming tidied up.