### PR TITLE
Doctor skill: teach it schema_version 2 rather than bail on it (PF-3584)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -14,7 +14,7 @@
       "name": "tinyfish",
       "source": "./plugins/tinyfish",
       "description": "The complete web toolkit for your agent. Search the web, fetch clean content from URLs, automate browsers with natural language, and spin up headless browsers for full programmatic control.",
-      "version": "1.2.2",
+      "version": "1.2.3",
       "author": {
         "name": "TinyFish",
         "url": "https://tinyfish.ai"

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -74,8 +74,9 @@ the command to the user. Never report a skipped repair as a fix.
 
 In-agent, `/tinyfish:doctor` runs the same checks and additionally proves
 this harness can reach TinyFish — the one thing the CLI cannot verify, since
-it cannot borrow the harness's OAuth token. A `registration: pass` from the
-CLI means the config exists, not that a call would succeed.
+it cannot borrow the harness's OAuth token. For an OAuth registration a
+`registration: pass` from the CLI means the config exists, not that a call
+would succeed.
 
 ## No agent at all?
 

--- a/plugins/tinyfish/.claude-plugin/plugin.json
+++ b/plugins/tinyfish/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tinyfish",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "The complete web toolkit for your agent. Search the web and get answers in milliseconds. Fetch any URL and get clean markdown content back. Send a browser agent to navigate sites, fill forms, and extract structured data. Spin up a headless browser for full programmatic control when you need it.",
   "author": {
     "name": "TinyFish",

--- a/plugins/tinyfish/CHANGELOG.md
+++ b/plugins/tinyfish/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 1.2.3 (2026-08-17)
+
+### Changed
+- Skill: `/tinyfish:doctor` describes `schema_version` `1` and `2`, and bails only above `2`. The CLI now tests an API-key registration on the wire, so a stale key header comes back as a `fail` with a `connect` repair rather than a green check. Without this the 1.2.2 guard would have degraded every user to `--pretty` output the moment that CLI published.
+- Skill: `/tinyfish:doctor` states the real gate on Cursor's unattended repair. On `2` it is the CLI's authenticated call passing, not merely a credential resolving, since a revoked key still resolves.
+
+### Added
+- Skill: `/tinyfish:doctor` reads `warn`. A warn does not move the exit code and must not be repaired; `registered, API key present but unverified` means doctor cannot read the key's value to test it, which is every Codex install. Step 2 settles those.
+- Skill: `/tinyfish:doctor` preserves `repairs[]` order, since `auth login` now precedes `connect` and `connect` writes whichever key is stored.
+
 ## 1.2.2 (2026-08-17)
 
 ### Fixed

--- a/plugins/tinyfish/skills/doctor/SKILL.md
+++ b/plugins/tinyfish/skills/doctor/SKILL.md
@@ -23,16 +23,25 @@ npx -y @tiny-fish/cli@latest doctor --harness claude-code
 
 JSON on stdout: `schema_version`, `checks[]`, `harnesses[]`, `repairs[]`.
 
-Read `schema_version` before the fields. This skill describes `1`. The command pins
-`@latest`, so a newer CLI can hand you a shape you do not know: on anything other than `1`,
-stop reading fields, show the user `--pretty` output instead, and rely on step 2 for the
-verdict.
+Read `schema_version` before the fields. This skill describes `1` and `2`. The command pins
+`@latest`, so a newer CLI can hand you a shape you do not know: above `2`, stop reading
+fields, show the user `--pretty` output instead, and rely on step 2 for the verdict.
+
+The difference between the two is what a keyed registration proves. `2` tests an API-key
+registration on the wire, so a stale key header fails outright and earns a `connect` repair.
+`1` passes it on config presence alone, and step 2 is the only thing that catches it.
 
 | Exit | Meaning |
 |---|---|
 | `0` | every check passed |
 | `1` | a check failed — read `checks[]` |
 | `2` | doctor could not run; **stdout is empty**, the reason is on stderr |
+
+A `warn` is not a failure and does not move the exit code: doctor is saying it could not
+check something, not that it is broken. On `2`, `registered, API key present but unverified`
+means the key exists but doctor cannot read its value to test it, which is every Codex
+install and any harness whose config redacts the header. Never repair on a warn, prove it
+in step 2.
 
 `--pretty` only when showing a human the list. Never put `--debug` output in a report —
 it is the one channel carrying raw stacks and absolute paths.
@@ -59,21 +68,26 @@ namespace names it.
 | Auth error, but doctor says `registered: yes` | Registration exists; the credential behind it is broken |
 | TinyFish tools absent entirely | Server not loaded in this session — the user must restart the agent |
 
-A `registration: pass` is presence, not proof — doctor reads config, not the wire. A stale
-API key in a config header passes that check and still fails every call, and a healthy
-sibling server will answer cheerfully while the broken one stays broken.
+What a `registration: pass` proves depends on `schema_version`. On `2` an API-key
+registration was tested on the wire, so a stale key header is already a `fail` with a
+`connect` repair beside it. On `1`, and on every OAuth or `auth_mode: unknown` registration
+at either version, pass is presence only: doctor read config, not the wire, and a stale key
+still passes while every call 401s. Neither version says anything about siblings, and a
+healthy sibling will answer cheerfully while the broken one stays broken.
 
 ## 3. Repair
 
-Run only commands that appear in `repairs[]`, and show `command` before running it.
+Run only commands that appear in `repairs[]`, and show `command` before running it. Keep
+the order they arrive in: `auth login` comes before `connect` because `connect` writes
+whichever key is stored, so a dead one has to be replaced first.
 
 - Terminal with the user present → `doctor --fix --harness claude-code`
 - Non-interactive → `doctor --fix --yes`; only `unattended_safe: true` repairs run and the
   rest return as skipped. Never report a skipped repair as a fix.
 - `unattended_safe: false` → hand it to the user, do not run it. Expect most repairs to be
   false: `auth login` always is, and `connect <harness>` is unsafe for every harness except
-  Cursor — and Cursor only while the CLI's own credential resolves. Read the field, do not
-  infer it from the command.
+  Cursor — and on `2` Cursor only while the CLI's own authenticated call passes, since a
+  revoked key still resolves as a credential. Read the field, do not infer it.
 - OAuth credential failures have no CLI repair: tell the user to run `/mcp`, pick tinyfish, and sign in.
 
 Re-run step 2 after any repair. Success means showing the real search result — the user

--- a/skills-src/doctor.md
+++ b/skills-src/doctor.md
@@ -23,16 +23,25 @@ npx -y @tiny-fish/cli@latest doctor{{HARNESS_FLAG}}
 
 JSON on stdout: `schema_version`, `checks[]`, `harnesses[]`, `repairs[]`.
 
-Read `schema_version` before the fields. This skill describes `1`. The command pins
-`@latest`, so a newer CLI can hand you a shape you do not know: on anything other than `1`,
-stop reading fields, show the user `--pretty` output instead, and rely on step 2 for the
-verdict.
+Read `schema_version` before the fields. This skill describes `1` and `2`. The command pins
+`@latest`, so a newer CLI can hand you a shape you do not know: above `2`, stop reading
+fields, show the user `--pretty` output instead, and rely on step 2 for the verdict.
+
+The difference between the two is what a keyed registration proves. `2` tests an API-key
+registration on the wire, so a stale key header fails outright and earns a `connect` repair.
+`1` passes it on config presence alone, and step 2 is the only thing that catches it.
 
 | Exit | Meaning |
 |---|---|
 | `0` | every check passed |
 | `1` | a check failed — read `checks[]` |
 | `2` | doctor could not run; **stdout is empty**, the reason is on stderr |
+
+A `warn` is not a failure and does not move the exit code: doctor is saying it could not
+check something, not that it is broken. On `2`, `registered, API key present but unverified`
+means the key exists but doctor cannot read its value to test it, which is every Codex
+install and any harness whose config redacts the header. Never repair on a warn, prove it
+in step 2.
 
 `--pretty` only when showing a human the list. Never put `--debug` output in a report —
 it is the one channel carrying raw stacks and absolute paths.
@@ -59,21 +68,26 @@ namespace names it.
 | Auth error, but doctor says `registered: yes` | Registration exists; the credential behind it is broken |
 | TinyFish tools absent entirely | Server not loaded in this session — the user must restart the agent |
 
-A `registration: pass` is presence, not proof — doctor reads config, not the wire. A stale
-API key in a config header passes that check and still fails every call, and a healthy
-sibling server will answer cheerfully while the broken one stays broken.
+What a `registration: pass` proves depends on `schema_version`. On `2` an API-key
+registration was tested on the wire, so a stale key header is already a `fail` with a
+`connect` repair beside it. On `1`, and on every OAuth or `auth_mode: unknown` registration
+at either version, pass is presence only: doctor read config, not the wire, and a stale key
+still passes while every call 401s. Neither version says anything about siblings, and a
+healthy sibling will answer cheerfully while the broken one stays broken.
 
 ## 3. Repair
 
-Run only commands that appear in `repairs[]`, and show `command` before running it.
+Run only commands that appear in `repairs[]`, and show `command` before running it. Keep
+the order they arrive in: `auth login` comes before `connect` because `connect` writes
+whichever key is stored, so a dead one has to be replaced first.
 
 - Terminal with the user present → `doctor --fix{{HARNESS_FLAG}}`
 - Non-interactive → `doctor --fix --yes`; only `unattended_safe: true` repairs run and the
   rest return as skipped. Never report a skipped repair as a fix.
 - `unattended_safe: false` → hand it to the user, do not run it. Expect most repairs to be
   false: `auth login` always is, and `connect <harness>` is unsafe for every harness except
-  Cursor — and Cursor only while the CLI's own credential resolves. Read the field, do not
-  infer it from the command.
+  Cursor — and on `2` Cursor only while the CLI's own authenticated call passes, since a
+  revoked key still resolves as a credential. Read the field, do not infer it.
 - OAuth credential failures have no CLI repair: {{REAUTH}}
 
 Re-run step 2 after any repair. Success means showing the real search result — the user

--- a/skills/tinyfish-doctor/SKILL.md
+++ b/skills/tinyfish-doctor/SKILL.md
@@ -23,16 +23,25 @@ npx -y @tiny-fish/cli@latest doctor
 
 JSON on stdout: `schema_version`, `checks[]`, `harnesses[]`, `repairs[]`.
 
-Read `schema_version` before the fields. This skill describes `1`. The command pins
-`@latest`, so a newer CLI can hand you a shape you do not know: on anything other than `1`,
-stop reading fields, show the user `--pretty` output instead, and rely on step 2 for the
-verdict.
+Read `schema_version` before the fields. This skill describes `1` and `2`. The command pins
+`@latest`, so a newer CLI can hand you a shape you do not know: above `2`, stop reading
+fields, show the user `--pretty` output instead, and rely on step 2 for the verdict.
+
+The difference between the two is what a keyed registration proves. `2` tests an API-key
+registration on the wire, so a stale key header fails outright and earns a `connect` repair.
+`1` passes it on config presence alone, and step 2 is the only thing that catches it.
 
 | Exit | Meaning |
 |---|---|
 | `0` | every check passed |
 | `1` | a check failed — read `checks[]` |
 | `2` | doctor could not run; **stdout is empty**, the reason is on stderr |
+
+A `warn` is not a failure and does not move the exit code: doctor is saying it could not
+check something, not that it is broken. On `2`, `registered, API key present but unverified`
+means the key exists but doctor cannot read its value to test it, which is every Codex
+install and any harness whose config redacts the header. Never repair on a warn, prove it
+in step 2.
 
 `--pretty` only when showing a human the list. Never put `--debug` output in a report —
 it is the one channel carrying raw stacks and absolute paths.
@@ -59,21 +68,26 @@ namespace names it.
 | Auth error, but doctor says `registered: yes` | Registration exists; the credential behind it is broken |
 | TinyFish tools absent entirely | Server not loaded in this session — the user must restart the agent |
 
-A `registration: pass` is presence, not proof — doctor reads config, not the wire. A stale
-API key in a config header passes that check and still fails every call, and a healthy
-sibling server will answer cheerfully while the broken one stays broken.
+What a `registration: pass` proves depends on `schema_version`. On `2` an API-key
+registration was tested on the wire, so a stale key header is already a `fail` with a
+`connect` repair beside it. On `1`, and on every OAuth or `auth_mode: unknown` registration
+at either version, pass is presence only: doctor read config, not the wire, and a stale key
+still passes while every call 401s. Neither version says anything about siblings, and a
+healthy sibling will answer cheerfully while the broken one stays broken.
 
 ## 3. Repair
 
-Run only commands that appear in `repairs[]`, and show `command` before running it.
+Run only commands that appear in `repairs[]`, and show `command` before running it. Keep
+the order they arrive in: `auth login` comes before `connect` because `connect` writes
+whichever key is stored, so a dead one has to be replaced first.
 
 - Terminal with the user present → `doctor --fix`
 - Non-interactive → `doctor --fix --yes`; only `unattended_safe: true` repairs run and the
   rest return as skipped. Never report a skipped repair as a fix.
 - `unattended_safe: false` → hand it to the user, do not run it. Expect most repairs to be
   false: `auth login` always is, and `connect <harness>` is unsafe for every harness except
-  Cursor — and Cursor only while the CLI's own credential resolves. Read the field, do not
-  infer it from the command.
+  Cursor — and on `2` Cursor only while the CLI's own authenticated call passes, since a
+  revoked key still resolves as a credential. Read the field, do not infer it.
 - OAuth credential failures have no CLI repair: re-authenticate in the harness itself.
 
   | Harness | Re-auth |


### PR DESCRIPTION
Ships plugin **v1.2.3**. Rebased onto `main` now that #252 has squash-merged, so this is a single commit.

## Why this is now urgent rather than cosmetic

1.2.2 added a forward guard:

> Read `schema_version` before the fields. This skill describes `1`. [...] on anything other than `1`, stop reading fields, show the user `--pretty` output instead, and rely on step 2 for the verdict.

Good instinct, but the CLI shipping PF-3618 (ux-labs#4334) stamps `schema_version: 2`. The skill pins `@latest`, so **the moment that CLI publishes, that guard degrades every user to `--pretty` and drops `repairs[]` entirely.** This PR teaches the skill the new version instead: the guard now covers `1` and `2` and bails only above `2`.

## What the two versions actually differ on

#252's own "Upstream CLI issues found" list opened with:

> registration detection reports key **presence, not validity** — a stale key header passes as `registration: PASS` while every call 401s

That is what `2` fixes. So:

| | |
|---|---|
| `1` | a keyed registration passes on config presence. Step 2 is the only thing that catches a stale key |
| `2` | it was tested on the wire, so a stale key header is already a `fail` with a `connect` repair beside it |

Step 2 keeps its job either way: OAuth harnesses, `auth_mode: unknown` (every plugin install), and the sibling-server problem #252 fixed are all untouched by the CLI change.

## Three smaller consequences of the same CLI change

- **`warn` needed saying out loud.** A keyed registration whose value doctor cannot read reports "API key present but unverified", which is every Codex install (it reports api-key from an env var name doctor cannot resolve). It does not move the exit code and must not be repaired.
- **`repairs[]` order is load-bearing.** `auth login` precedes `connect`, because `connect` writes whichever key is stored and a dead one has to be replaced first.
- **Cursor's unattended repair has a different gate than 1.2.2 states.** 1.2.2 says "while the CLI's own credential resolves". On `2` it is the CLI's *authenticated call* passing: a revoked key resolves as a credential perfectly well and still cannot write a working header.

## Verified

`node scripts/validate-skills.mjs` passes: generated variants in sync with `skills-src/`, frontmatter under the 1024-char Codex limit, marketplace entry and `plugin.json` both at 1.2.3.

## Sequencing

Safe to merge before the CLI publishes: the skill reads `schema_version` at runtime and both branches are correct. Merging it *after* the CLI publishes leaves a window where installed copies bail to `--pretty`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)